### PR TITLE
Unit test cleanup

### DIFF
--- a/mdio/acceptance_test.cc
+++ b/mdio/acceptance_test.cc
@@ -1688,9 +1688,7 @@ TEST(Dataset, listVars) {
   ASSERT_TRUE(dataset.status().ok()) << dataset.status();
 
   std::vector<std::string> varList = dataset.value().variables.get_keys();
-  for (auto& name : varList) {
-    std::cout << "Variable name: " << name << "\n";
-  }
+  EXPECT_TRUE(varList.size() == 9) << "No variables found in dataset";
 }
 
 TEST(Dataset, selectField) {
@@ -1700,24 +1698,27 @@ TEST(Dataset, selectField) {
 
   ASSERT_TRUE(dataset.status().ok()) << dataset.status();
   auto ds = dataset.value();
-  std::cout << ds.get_variable(name).value() << std::endl;
-  EXPECT_TRUE(ds.SelectField("image_headers", "cdp-x").status().ok())
-      << "Failed to pull cdp-x from image_headers";
-  std::cout << ds.get_variable(name).value() << std::endl;
-  EXPECT_TRUE(ds.SelectField("image_headers", "elevation").status().ok())
-      << "Failed to pull elevation from image_headers";
-  std::cout << ds.get_variable(name).value() << std::endl;
-  EXPECT_TRUE(ds.SelectField("image_headers", "").status().ok())
-      << "Failed to set to byte array";
-  std::cout << ds.get_variable(name).value() << std::endl;
-  EXPECT_FALSE(ds.SelectField("image", "NotAField").status().ok())
-      << "Somehow pulled NotAField from image";
-  EXPECT_FALSE(ds.SelectField("NotAVariable", "NotAField").status().ok())
-      << "Somehow pulled NotAField from "
-         "NotAVariable";
-  EXPECT_FALSE(ds.SelectField("image_headers", "NotAField").status().ok())
-      << "Somehow pulled NotAField from "
-         "image_headers";
+
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kByte) << "Failed to pull byte array from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 3) << "Expected structarray to be of rank 3";
+
+  EXPECT_TRUE(ds.SelectField("image_headers", "cdp-x").status().ok()) << "Failed to pull cdp-x from image_headers";
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kInt32) << "Failed to pull int32 from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 2) << "Expected cdp-x to be of rank 2";
+
+  EXPECT_TRUE(ds.SelectField("image_headers", "elevation").status().ok()) << "Failed to pull elevation from image_headers";
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kFloat16) << "Failed to pull float16 from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 2) << "Expected elevation to be of rank 2";
+
+  EXPECT_TRUE(ds.SelectField("image_headers", "").status().ok()) << "Failed to set to byte array";
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kByte) << "Failed to pull byte array from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 3) << "Expected structarray to be of rank 3";
+
+  EXPECT_FALSE(ds.SelectField("image", "NotAField").status().ok()) << "Somehow pulled NotAField from image";
+
+  EXPECT_FALSE(ds.SelectField("NotAVariable", "NotAField").status().ok()) << "Somehow pulled NotAField from NotAVariable";
+
+  EXPECT_FALSE(ds.SelectField("image_headers", "NotAField").status().ok()) << "Somehow pulled NotAField from image_headers";
 }
 
 TEST(Dataset, TEARDOWN) {

--- a/mdio/acceptance_test.cc
+++ b/mdio/acceptance_test.cc
@@ -1699,26 +1699,41 @@ TEST(Dataset, selectField) {
   ASSERT_TRUE(dataset.status().ok()) << dataset.status();
   auto ds = dataset.value();
 
-  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kByte) << "Failed to pull byte array from image_headers";
-  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 3) << "Expected structarray to be of rank 3";
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kByte)
+      << "Failed to pull byte array from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 3)
+      << "Expected structarray to be of rank 3";
 
-  EXPECT_TRUE(ds.SelectField("image_headers", "cdp-x").status().ok()) << "Failed to pull cdp-x from image_headers";
-  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kInt32) << "Failed to pull int32 from image_headers";
-  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 2) << "Expected cdp-x to be of rank 2";
+  EXPECT_TRUE(ds.SelectField("image_headers", "cdp-x").status().ok())
+      << "Failed to pull cdp-x from image_headers";
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kInt32)
+      << "Failed to pull int32 from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 2)
+      << "Expected cdp-x to be of rank 2";
 
-  EXPECT_TRUE(ds.SelectField("image_headers", "elevation").status().ok()) << "Failed to pull elevation from image_headers";
-  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kFloat16) << "Failed to pull float16 from image_headers";
-  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 2) << "Expected elevation to be of rank 2";
+  EXPECT_TRUE(ds.SelectField("image_headers", "elevation").status().ok())
+      << "Failed to pull elevation from image_headers";
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() ==
+              mdio::constants::kFloat16)
+      << "Failed to pull float16 from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 2)
+      << "Expected elevation to be of rank 2";
 
-  EXPECT_TRUE(ds.SelectField("image_headers", "").status().ok()) << "Failed to set to byte array";
-  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kByte) << "Failed to pull byte array from image_headers";
-  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 3) << "Expected structarray to be of rank 3";
+  EXPECT_TRUE(ds.SelectField("image_headers", "").status().ok())
+      << "Failed to set to byte array";
+  EXPECT_TRUE(ds.get_variable(name).value().dtype() == mdio::constants::kByte)
+      << "Failed to pull byte array from image_headers";
+  EXPECT_EQ(ds.get_variable(name).value().get_store().rank(), 3)
+      << "Expected structarray to be of rank 3";
 
-  EXPECT_FALSE(ds.SelectField("image", "NotAField").status().ok()) << "Somehow pulled NotAField from image";
+  EXPECT_FALSE(ds.SelectField("image", "NotAField").status().ok())
+      << "Somehow pulled NotAField from image";
 
-  EXPECT_FALSE(ds.SelectField("NotAVariable", "NotAField").status().ok()) << "Somehow pulled NotAField from NotAVariable";
+  EXPECT_FALSE(ds.SelectField("NotAVariable", "NotAField").status().ok())
+      << "Somehow pulled NotAField from NotAVariable";
 
-  EXPECT_FALSE(ds.SelectField("image_headers", "NotAField").status().ok()) << "Somehow pulled NotAField from image_headers";
+  EXPECT_FALSE(ds.SelectField("image_headers", "NotAField").status().ok())
+      << "Somehow pulled NotAField from image_headers";
 }
 
 TEST(Dataset, TEARDOWN) {

--- a/mdio/acceptance_test.cc
+++ b/mdio/acceptance_test.cc
@@ -1693,7 +1693,7 @@ TEST(Dataset, listVars) {
   }
 }
 
-TEST(Dataset, SelectField) {
+TEST(Dataset, selectField) {
   std::string path = "zarrs/acceptance";
   auto dataset = mdio::Dataset::Open(path, mdio::constants::kOpen);
   std::string name = "image_headers";

--- a/mdio/dataset_factory_test.cc
+++ b/mdio/dataset_factory_test.cc
@@ -167,12 +167,6 @@ TEST(Toy, create) {
   res = Construct(j, "zarrs/toy_dataset");
 
   ASSERT_TRUE(res.status().ok()) << res.status();
-
-  nlohmann::json metadata = std::get<0>(res.value());
-  std::vector<nlohmann::json> variables = std::get<1>(res.value());
-  for (auto& variable : variables) {
-    std::cout << variable.dump() << "\n\n";
-  }
 }
 
 TEST(Teapot, create) {
@@ -361,12 +355,6 @@ TEST(Teapot, create) {
   nlohmann::json j = nlohmann::json::parse(teapotSchema);
   auto res = Construct(j, "zarrs/teapot_dome_3d");
   ASSERT_TRUE(res.status().ok()) << res.status();
-
-  nlohmann::json metadata = std::get<0>(res.value());
-  std::vector<nlohmann::json> variables = std::get<1>(res.value());
-  for (auto& variable : variables) {
-    std::cout << variable.dump() << "\n\n";
-  }
 }
 
 TEST(Variable, createTeapot) {
@@ -556,7 +544,7 @@ TEST(Variable, createTeapot) {
   auto res = Construct(j, "zarrs/teapot_dome_3d");
   ASSERT_TRUE(res.status().ok()) << res.status();
 
-  nlohmann::json metadata = std::get<0>(res.value());
+  nlohmann::json metadata = std::get<0>(res.value());  // NOLINT UNUSED
   std::vector<nlohmann::json> variables = std::get<1>(res.value());
   for (auto& variable : variables) {
     auto varStatus =
@@ -610,7 +598,7 @@ TEST(Variable, simple) {
   auto res = Construct(j, "zarrs/simple_dataset");
   ASSERT_TRUE(res.status().ok()) << res.status();
 
-  nlohmann::json metadata = std::get<0>(res.value());
+  nlohmann::json metadata = std::get<0>(res.value());  // NOLINT UNUSED
   std::vector<nlohmann::json> variables = std::get<1>(res.value());
   for (auto& variable : variables) {
     auto varStatus =
@@ -624,7 +612,7 @@ TEST(Xarray, open) {
   auto res = Construct(j, "zarrs/simple_dataset");
   ASSERT_TRUE(res.status().ok()) << res.status();
 
-  nlohmann::json metadata = std::get<0>(res.value());
+  nlohmann::json metadata = std::get<0>(res.value());  // NOLINT UNUSED
   std::vector<nlohmann::json> variables = std::get<1>(res.value());
   for (auto& variable : variables) {
     variable.erase("attributes");

--- a/mdio/dataset_factory_test.cc
+++ b/mdio/dataset_factory_test.cc
@@ -619,7 +619,7 @@ TEST(Variable, simple) {
   }
 }
 
-TEST(xarray, open) {
+TEST(Xarray, open) {
   nlohmann::json j = nlohmann::json::parse(manifest);
   auto res = Construct(j, "zarrs/simple_dataset");
   ASSERT_TRUE(res.status().ok()) << res.status();

--- a/mdio/dataset_test.cc
+++ b/mdio/dataset_test.cc
@@ -294,7 +294,7 @@ TEST(Dataset, isel) {
       << "Inline range should end at 5";
 }
 
-TEST(Dataset, FromConsolidatedMeta) {
+TEST(Dataset, fromConsolidatedMeta) {
   auto json_vars = GetToyExample();
 
   auto dataset = mdio::Dataset::from_json(json_vars, "zarrs/acceptance",
@@ -311,7 +311,7 @@ TEST(Dataset, FromConsolidatedMeta) {
   std::cout << new_dataset.value() << std::endl;
 }
 
-TEST(Dataset, Open) {
+TEST(Dataset, open) {
   auto json_schema = GetToyExample();
 
   auto validated_schema = Construct(json_schema, "zarrs/acceptance");
@@ -331,7 +331,7 @@ TEST(Dataset, Open) {
   std::cout << result.value() << std::endl;
 }
 
-TEST(Dataset, OpenWithContext) {
+TEST(Dataset, openWithContext) {
   // tests the struct array on creation
   auto concurrency_json =
       ::nlohmann::json::parse(R"({"data_copy_concurrency": {"limit": 2}})");
@@ -360,7 +360,7 @@ TEST(Dataset, OpenWithContext) {
   std::cout << result.value() << std::endl;
 }
 
-TEST(Dataset, FromJson) {
+TEST(Dataset, fromJson) {
   auto json_vars = GetToyExample();
 
   auto dataset = mdio::Dataset::from_json(json_vars, "zarrs/acceptance",
@@ -370,7 +370,7 @@ TEST(Dataset, FromJson) {
   std::cout << dataset.status() << std::endl;
 }
 
-TEST(Dataset, MultiFuture) {
+TEST(Dataset, multiFuture) {
   auto json_vars = make_vars();
 
   std::vector<mdio::Future<mdio::Variable<>>> variables;
@@ -452,7 +452,7 @@ TEST(Dataset, create) {
       << "Dataset successfully overwrote an existing dataset!";
 }
 
-TEST(Dataset, CommitMetadata) {
+TEST(Dataset, commitMetadata) {
   std::cout << "NOTICE: After this test is run, please verify the contents of "
                "'image' are still correct!\n";
   std::filesystem::remove_all("zarrs/acceptance");
@@ -479,7 +479,7 @@ TEST(Dataset, CommitMetadata) {
   EXPECT_TRUE(commitRes.status().ok()) << commitRes.status();
 }
 
-TEST(Dataset, CommitSlicedMetadata) {
+TEST(Dataset, commitSlicedMetadata) {
   std::filesystem::remove_all("zarrs/acceptance");
   auto json_vars = GetToyExample();
 

--- a/mdio/dataset_test.cc
+++ b/mdio/dataset_test.cc
@@ -246,11 +246,14 @@ mdio::Dataset make() {
 TEST(DatasetSpec, valid) {
   auto dataset = make();
 
-  for (const auto& i : dataset.variables.get_keys()) {
-    std::cout << i << std::endl;
-  }
+  // Use the iterable accessor to get sorted keys
+  auto keys = dataset.variables.get_iterable_accessor();
+  ASSERT_TRUE(keys.size() == 2) << "Expected 2 variables in the dataset";
+  EXPECT_TRUE(keys[0] == "var1") << "Expected first variable to be var1";
+  EXPECT_TRUE(keys[1] == "var2") << "Expected second variable to be var2";
+
   auto result = dataset.variables.get("var1");
-  std::cout << result.status() << std::endl;
+  ASSERT_TRUE(result.status().ok()) << result.status();
 }
 
 TEST(Dataset, isel) {
@@ -307,8 +310,7 @@ TEST(Dataset, fromConsolidatedMeta) {
 
   auto new_dataset =
       mdio::Dataset::Open(dataset_path, mdio::constants::kOpen).result();
-  std::cout << new_dataset.status() << std::endl;
-  std::cout << new_dataset.value() << std::endl;
+  ASSERT_TRUE(new_dataset.status().ok()) << new_dataset.status();
 }
 
 TEST(Dataset, open) {
@@ -320,15 +322,11 @@ TEST(Dataset, open) {
 
   auto [metadata, json_vars] = validated_schema.value();
 
-  std::cout << json_vars[0] << std::endl;
-
   auto result =
       mdio::Dataset::Open(metadata, json_vars, mdio::constants::kCreateClean)
           .result();
 
   ASSERT_TRUE(result.ok());
-
-  std::cout << result.value() << std::endl;
 }
 
 TEST(Dataset, openWithContext) {
@@ -349,15 +347,11 @@ TEST(Dataset, openWithContext) {
 
   auto [metadata, json_vars] = validated_schema.value();
 
-  std::cout << json_vars[0] << std::endl;
-
   auto result = mdio::Dataset::Open(metadata, json_vars,
                                     mdio::constants::kCreateClean, context)
                     .result();
 
   ASSERT_TRUE(result.ok());
-
-  std::cout << result.value() << std::endl;
 }
 
 TEST(Dataset, fromJson) {
@@ -367,7 +361,7 @@ TEST(Dataset, fromJson) {
                                           mdio::constants::kCreateClean)
                      .result();
 
-  std::cout << dataset.status() << std::endl;
+  ASSERT_TRUE(dataset.status().ok()) << dataset.status();
 }
 
 TEST(Dataset, multiFuture) {
@@ -398,15 +392,17 @@ TEST(Dataset, multiFuture) {
 
   auto all_done_future = tensorstore::WaitAllFuture(futures);
 
-  for (auto var : variables) {
-    std::cout << var.ready() << std::endl;
-  }
+  // It may be the case that some futures become ready before this.
+  // for (auto var : variables) {
+  //   EXPECT_FALSE(var.ready());
+  // }
 
   all_done_future.Wait();
-  std::cout << all_done_future.result().status() << std::endl;
+  ASSERT_TRUE(all_done_future.result().status().ok())
+      << all_done_future.result().status();
 
   for (auto var : variables) {
-    std::cout << var.ready() << std::endl;
+    ASSERT_TRUE(var.result().status().ok()) << var.result().status();
   }
 }
 
@@ -453,8 +449,7 @@ TEST(Dataset, create) {
 }
 
 TEST(Dataset, commitMetadata) {
-  std::cout << "NOTICE: After this test is run, please verify the contents of "
-               "'image' are still correct!\n";
+  const std::string path = "zarrs/acceptance";
   std::filesystem::remove_all("zarrs/acceptance");
   auto json_vars = GetToyExample();
 
@@ -476,7 +471,29 @@ TEST(Dataset, commitMetadata) {
 
   auto commitRes = dataset.CommitMetadata();
 
-  EXPECT_TRUE(commitRes.status().ok()) << commitRes.status();
+  ASSERT_TRUE(commitRes.status().ok()) << commitRes.status();
+
+  auto newDataset = mdio::Dataset::Open(path, mdio::constants::kOpen);
+  ASSERT_TRUE(newDataset.status().ok()) << newDataset.status();
+
+  auto newImageRes = newDataset.value().variables.at("image");
+  ASSERT_TRUE(newImageRes.ok()) << newImageRes.status();
+
+  nlohmann::json metadata = newImageRes.value().getMetadata();
+  ASSERT_TRUE(metadata.contains("statsV1"))
+      << "Did not find statsV1 in metadata";
+  ASSERT_TRUE(metadata["statsV1"].contains("histogram"))
+      << "Did not find histogram in statsV1";
+  ASSERT_TRUE(metadata["statsV1"]["histogram"].contains("binCenters"))
+      << "Did not find binCenters in histogram";
+  EXPECT_TRUE(metadata["statsV1"]["histogram"]["binCenters"] ==
+              std::vector<float>({2, 4, 6}))
+      << "Expected binCenters to be [2, 4, 6] but got "
+      << metadata["statsV1"]["histogram"]["binCenters"];
+  EXPECT_TRUE(metadata["statsV1"]["histogram"]["counts"] ==
+              std::vector<float>({10, 15, 20}))
+      << "Expected counts to be [10, 15, 20] but got "
+      << metadata["statsV1"]["histogram"]["counts"];
 }
 
 TEST(Dataset, commitSlicedMetadata) {

--- a/mdio/dataset_validator_test.cc
+++ b/mdio/dataset_validator_test.cc
@@ -21,7 +21,7 @@
 
 namespace {
 
-TEST(schema, minimal) {
+TEST(Schema, minimal) {
   std::string schema = R"(
         {
   "metadata": {
@@ -73,7 +73,7 @@ TEST(schema, minimal) {
   EXPECT_TRUE(status.ok()) << status;
 }
 
-TEST(schema, valid) {
+TEST(Schema, valid) {
   std::string schema = R"(
         {
   "metadata": {
@@ -213,7 +213,7 @@ TEST(schema, valid) {
   EXPECT_TRUE(status.ok()) << status;
 }
 
-TEST(schema, invalid) {
+TEST(Schema, invalid) {
   std::string schema = R"(
         {
   "metadata": {
@@ -353,7 +353,7 @@ TEST(schema, invalid) {
   EXPECT_FALSE(status.ok()) << status;
 }
 
-TEST(validateCoords, valid) {
+TEST(ValidateCoords, valid) {
   std::string schema = R"(
         {
   "metadata": {
@@ -493,7 +493,7 @@ TEST(validateCoords, valid) {
   EXPECT_TRUE(status.ok()) << status;
 }
 
-TEST(validateCoords, invalid) {
+TEST(ValidateCoords, invalid) {
   std::string schema = R"(
         {
   "metadata": {
@@ -628,7 +628,7 @@ TEST(validateCoords, invalid) {
   EXPECT_FALSE(status.ok()) << status;
 }
 
-TEST(validateCoords, invalid2) {
+TEST(ValidateCoords, invalid2) {
   std::string schema = R"(
         {
   "metadata": {
@@ -757,7 +757,7 @@ TEST(validateCoords, invalid2) {
   EXPECT_FALSE(status.ok()) << status;
 }
 
-TEST(validate, valid) {
+TEST(Validate, valid) {
   std::string schema = R"(
         {
   "metadata": {
@@ -897,13 +897,13 @@ TEST(validate, valid) {
   EXPECT_TRUE(status.ok()) << status;
 }
 
-TEST(validate, invalid) { EXPECT_TRUE(true); }
+TEST(Validate, invalid) { EXPECT_TRUE(true); }
 
-TEST(datetime, valid) {
+TEST(Datetime, valid) {
   EXPECT_TRUE(isISO8601DateTime("2023-12-12T15:02:06.413469-06:00"));
 }
 
-TEST(datetime, invalid) {
+TEST(Datetime, invalid) {
   EXPECT_FALSE(isISO8601DateTime("2023-12-12T15:02:06.413469-06:"));
 }
 

--- a/mdio/stats_test.cc
+++ b/mdio/stats_test.cc
@@ -39,14 +39,14 @@ auto getEdgeHist() {
       binEdges, binWidths, counts);
 }
 
-TEST(HistogramTest, ConstructCenterHist) {
+TEST(HistogramTest, constructCenterHist) {
   auto histogram = getCenterHist();
   nlohmann::json expected = {
       {"histogram", {{"binCenters", {1.0, 2.0, 3.0}}, {"counts", {1, 2, 3}}}}};
   EXPECT_EQ(histogram->getHistogram(), expected);
 }
 
-TEST(HistogramTest, ConstructEdgeHist) {
+TEST(HistogramTest, constructEdgeHist) {
   auto histogram = getEdgeHist();
   nlohmann::json expected = {{"histogram",
                               {{"binEdges", {0.0, 1.0, 2.0, 3.0}},
@@ -55,19 +55,19 @@ TEST(HistogramTest, ConstructEdgeHist) {
   EXPECT_EQ(histogram->getHistogram(), expected);
 }
 
-TEST(HistogramTest, CenteredBinHistogramClone) {
+TEST(HistogramTest, centeredBinHistogramClone) {
   auto histogram = getCenterHist();
   auto clone = histogram->clone();
   EXPECT_EQ(clone->getHistogram(), histogram->getHistogram());
 }
 
-TEST(HistogramTest, EdgeDefinedHistogramClone) {
+TEST(HistogramTest, edgeDefinedHistogramClone) {
   auto histogram = getEdgeHist();
   auto clone = histogram->clone();
   EXPECT_EQ(clone->getHistogram(), histogram->getHistogram());
 }
 
-TEST(HistogramTest, CenteredFromJSON) {
+TEST(HistogramTest, centeredFromJSON) {
   nlohmann::json expected = {
       {"histogram", {{"binCenters", {1.0, 2.0, 3.0}}, {"counts", {1, 2, 3}}}}};
   auto inertHist = mdio::internal::CenteredBinHistogram<float>({}, {});
@@ -77,7 +77,7 @@ TEST(HistogramTest, CenteredFromJSON) {
   EXPECT_EQ(histogram->getHistogram(), expected);
 }
 
-TEST(HistogramTest, EdgeFromJSON) {
+TEST(HistogramTest, edgeFromJSON) {
   nlohmann::json expected = {{"histogram",
                               {{"binEdges", {0.0, 1.0, 2.0, 3.0}},
                                {"binWidths", {1.0, 1.0, 1.0}},
@@ -89,7 +89,7 @@ TEST(HistogramTest, EdgeFromJSON) {
   EXPECT_EQ(histogram->getHistogram(), expected);
 }
 
-TEST(SummaryStatsTest, FromJson) {
+TEST(SummaryStatsTest, fromJson) {
   nlohmann::json expected = {
       {"count", 100},
       {"min", -1000.0},
@@ -103,7 +103,7 @@ TEST(SummaryStatsTest, FromJson) {
   EXPECT_EQ(stats.getBindable(), expected);
 }
 
-TEST(SummaryStatsTest, FromJsonInt) {
+TEST(SummaryStatsTest, fromJsonInt) {
   nlohmann::json expected = {
       {"count", 100},
       {"min", -1000},
@@ -117,7 +117,7 @@ TEST(SummaryStatsTest, FromJsonInt) {
   EXPECT_EQ(stats.getBindable(), expected);
 }
 
-TEST(UserAttributesTest, FromJsonNoStats) {
+TEST(UserAttributesTest, fromJsonNoStats) {
   nlohmann::json expected = {{"attributes",
                               {{"foo", "bar"},
                                {"life", 42},
@@ -131,7 +131,7 @@ TEST(UserAttributesTest, FromJsonNoStats) {
   EXPECT_EQ(attrs.ToJson(), expected);
 }
 
-TEST(UserAttributesTest, FromJsonNoAttrs) {
+TEST(UserAttributesTest, fromJsonNoAttrs) {
   nlohmann::json expected = {
       {"statsV1",
        {{"histogram", {{"binCenters", {1.0, 2.0, 3.0}}, {"counts", {1, 2, 3}}}},
@@ -146,7 +146,7 @@ TEST(UserAttributesTest, FromJsonNoAttrs) {
   EXPECT_EQ(attrs.ToJson(), expected);
 }
 
-TEST(UserAttributesTest, Nothing) {
+TEST(UserAttributesTest, nothing) {
   nlohmann::json expected = nlohmann::json::object();
   auto attrs = mdio::UserAttributes::FromJson(expected);
   EXPECT_EQ(attrs.value().ToJson(), expected);
@@ -155,7 +155,7 @@ TEST(UserAttributesTest, Nothing) {
   EXPECT_EQ(none.value().ToJson(), expected);
 }
 
-TEST(UserAttributesTest, FromJsonWithAttrs) {
+TEST(UserAttributesTest, fromJsonWithAttrs) {
   nlohmann::json expected = {
       {"statsV1",
        {{"histogram", {{"binCenters", {1.0, 2.0, 3.0}}, {"counts", {1, 2, 3}}}},
@@ -177,7 +177,7 @@ TEST(UserAttributesTest, FromJsonWithAttrs) {
   EXPECT_EQ(attrs.ToJson(), expected);
 }
 
-TEST(UserAttributesTest, FromJsonStatsList) {
+TEST(UserAttributesTest, fromJsonStatsList) {
   nlohmann::json expected = {
       {"statsV1",
        {{{"histogram",
@@ -209,7 +209,7 @@ TEST(UserAttributesTest, FromJsonStatsList) {
   EXPECT_EQ(attrs.ToJson(), expected);
 }
 
-TEST(UserAttributesTest, FromDataset) {
+TEST(UserAttributesTest, fromDataset) {
   std::string schema = R"(
         {
   "metadata": {
@@ -383,7 +383,7 @@ TEST(UserAttributesTest, FromDataset) {
             "Variable xline not found in Dataset");
 }
 
-TEST(UserAttributes, LocationAndReassignment) {
+TEST(UserAttributes, locationAndReassignment) {
   nlohmann::json expected = {
       {"statsV1",
        {{"histogram", {{"binCenters", {1.0, 2.0, 3.0}}, {"counts", {1, 2, 3}}}},

--- a/mdio/utils_test.cc
+++ b/mdio/utils_test.cc
@@ -188,8 +188,6 @@ TEST(TrimDataset, oneSlice) {
   ASSERT_TRUE(res.status().ok()) << res.status();
   auto dsRes = mdio::Dataset::Open(kTestPath, mdio::constants::kOpen);
   ASSERT_TRUE(dsRes.status().ok()) << dsRes.status();
-  auto ds = dsRes.value();
-  std::cout << ds << std::endl;
 }
 
 TEST(TrimDataset, oneSliceData) {

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -285,6 +285,7 @@ TEST(Variable, structArray) {
 
   auto domain = variable->dimensions();
   // TODO(BrianMichell) - we might assign a "byte" label
+  // This is a feature of Tensorstore
   EXPECT_THAT(domain.labels(), ::testing::ElementsAre("x", "y", ""));
 
   auto bytes = mdio::constants::kByte;
@@ -335,6 +336,7 @@ TEST(Variable, structArrayOpen) {
 
   auto domain = variable->dimensions();
   // TODO(BrianMichell) - we might assign a "byte" label
+  // This is a feature of Tensorstore
   EXPECT_THAT(domain.labels(), ::testing::ElementsAre("x", "y", ""));
 
   auto bytes = mdio::constants::kByte;

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -181,8 +181,10 @@ TEST(VariableData, conversion) {
 
   auto variable =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).result();
+  ASSERT_TRUE(variable.ok()) << variable.status();
 
   auto variable_a = mdio::from_variable<int16_t>(variable.value());
+  ASSERT_TRUE(variable_a.ok()) << variable_a.status();
   // we cant convert from dtype to a void though
 
   // we need to be able to cast to void

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -176,7 +176,7 @@ mdio::Result<::nlohmann::json> PopulateStore(const nlohmann::json& json_good) {
   return output_json;
 }
 
-TEST(VARIABLEDATA, CONVERSION) {
+TEST(VariableData, conversion) {
   using int16_t = mdio::dtypes::int16_t;
 
   auto variable =
@@ -197,7 +197,7 @@ TEST(VARIABLEDATA, CONVERSION) {
   EXPECT_EQ("name", variable_c.variableName);
 }
 
-TEST(VARIABLE, CONVERSION) {
+TEST(Variable, conversion) {
   // we need to be able to cast to void
   using int16_t = mdio::dtypes::int16_t;
   // Can convert this
@@ -209,7 +209,7 @@ TEST(VARIABLE, CONVERSION) {
   // mdio::Variable<int16_t> variable_d(variable_c);
 }
 
-TEST(VARIABLEDATA, FROMVARIABLE) {
+TEST(VariableData, fromVariable) {
   using int16_t = mdio::dtypes::int16_t;
 
   auto variable =
@@ -235,7 +235,7 @@ TEST(VARIABLEDATA, FROMVARIABLE) {
   // you can't do this data({0, 0}) because it's void, you would need to memcpy
 }
 
-TEST(VARIABLEDATA, FROMVARIABLE2) {
+TEST(VariableData, fromVariable2) {
   using int16_t = mdio::dtypes::int16_t;
 
   auto variable =
@@ -257,7 +257,7 @@ TEST(VARIABLEDATA, FROMVARIABLE2) {
   std::cout << data({0, 0}) << "\t" << data({1, 0}) << std::endl;
 }
 
-TEST(VARIABLE, CONTEXT) {
+TEST(Variable, context) {
   // tests the struct array on creation
   auto concurrency_json =
       ::nlohmann::json::parse(R"({"data_copy_concurrency": {"limit": 2}})");
@@ -272,7 +272,7 @@ TEST(VARIABLE, CONTEXT) {
           .result();
 }
 
-TEST(VARIABLE, STRUCTARRAY) {
+TEST(Variable, structArray) {
   // tests the struct array on creation
   auto json_spec = GetJsonSpecStruct();
 
@@ -293,7 +293,7 @@ TEST(VARIABLE, STRUCTARRAY) {
   std::filesystem::remove_all("test.zarr");
 }
 
-TEST(VARIABLE, STRUCTARRAYFIELD) {
+TEST(Variable, structArrayField) {
   auto json_spec = GetJsonSpecStruct();
   json_spec["field"] = "a";
 
@@ -312,7 +312,7 @@ TEST(VARIABLE, STRUCTARRAYFIELD) {
   std::filesystem::remove_all("test.zarr");
 }
 
-TEST(VARIABLE, STRUCTARRAYOPEN) {
+TEST(Variable, structArrayOpen) {
   // tests the struct array on open
   auto json_spec = GetJsonSpecStruct();
 
@@ -343,7 +343,7 @@ TEST(VARIABLE, STRUCTARRAYOPEN) {
   std::filesystem::remove_all("test.zarr");
 }
 
-TEST(VARIABLE, OPEN) {
+TEST(Variable, open) {
   auto variable =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).value();
 
@@ -365,7 +365,7 @@ TEST(VARIABLE, OPEN) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLE, OPENMETADATA) {
+TEST(Variable, openMetadata) {
   auto json = json_good["metadata"];
 
   /*
@@ -433,7 +433,7 @@ TEST(VARIABLE, OPENMETADATA) {
   */
 }
 
-TEST(VARIABLE, OPENEXISTING) {
+TEST(Variable, openExisting) {
   auto _variable =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).value();
 
@@ -456,7 +456,7 @@ TEST(VARIABLE, OPENEXISTING) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLE, MISMATCHATTRS) {
+TEST(Variable, mismatchAttrs) {
   nlohmann::json json = GetJsonSpecStruct();
   auto variable = mdio::Variable<>::Open(json, mdio::constants::kCreateClean);
   ASSERT_TRUE(variable.status().ok()) << variable.status();
@@ -475,7 +475,7 @@ TEST(VARIABLE, MISMATCHATTRS) {
   std::filesystem::remove_all("test.zarr");
 }
 
-TEST(VARIABLE, SLICE) {
+TEST(Variable, slice) {
   auto variable =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).value();
 
@@ -497,7 +497,7 @@ TEST(VARIABLE, SLICE) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLE, LABELEDARRAY) {
+TEST(Variable, labeledArray) {
   auto dimensions = tensorstore::Box({0, 0, 0}, {100, 200, 300});
 
   auto array = tensorstore::AllocateArray<mdio::dtypes::float32_t>(
@@ -537,7 +537,7 @@ TEST(VARIABLE, LABELEDARRAY) {
   // std::cout << array({0, 6, 0}) << std::endl;
 }
 
-TEST(VARIABLE, UserAttributes) {
+TEST(Variable, userAttributes) {
   auto var1Res = mdio::Variable<>::Open(GetJsonSpecStruct(),
                                         mdio::constants::kCreateClean);
   ASSERT_TRUE(var1Res.status().ok()) << var1Res.status();
@@ -577,7 +577,7 @@ TEST(VARIABLE, UserAttributes) {
 
 // If a slice is "out of bounds" it should automatically get resized to the
 // proper bounds.
-TEST(VARIABLE, OB_SLICE) {
+TEST(Variable, outOfBoundsSlice) {
   auto var =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).result();
 
@@ -629,7 +629,7 @@ TEST(VARIABLE, OB_SLICE) {
   EXPECT_TRUE(legal.status().ok()) << legal.status();
 }
 
-TEST(VARIABLEDATA, OB_SLICE) {
+TEST(VariableData, outOfBoundsSlice) {
   auto varRes =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).result();
 
@@ -657,7 +657,7 @@ TEST(VARIABLEDATA, OB_SLICE) {
       << "Step precondition was violated but still sliced";
 }
 
-TEST(VARIABLESPEC, OPEN) {
+TEST(VariableSpec, open) {
   // this is the whole thing
   auto creation =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).result();
@@ -706,7 +706,7 @@ TEST(VARIABLESPEC, OPEN) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLESPEC, CREATEVARIABLE) {
+TEST(VariableSpec, createVariable) {
   mdio::TransactionalOpenOptions options;
   auto opt = options.Set(std::move(mdio::constants::kCreateClean));
 
@@ -723,7 +723,7 @@ TEST(VARIABLESPEC, CREATEVARIABLE) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLESPEC, OPENVARIABLE) {
+TEST(VariableSpec, openVariable) {
   auto json_schema = mdio::internal::ValidateAndProcessJson(json_good).value();
   auto [json_store, metadata] = json_schema;
 
@@ -750,7 +750,7 @@ TEST(VARIABLESPEC, OPENVARIABLE) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLESPEC, SLICEVARIABLE) {
+TEST(VariableSpec, sliceVariable) {
   mdio::TransactionalOpenOptions options;
   auto opt = options.Set(std::move(mdio::constants::kCreateClean));
 
@@ -792,7 +792,7 @@ TEST(VARIABLESPEC, SLICEVARIABLE) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLEDATA, TESTCONSTRUCTION) {
+TEST(VariableData, testConstruction) {
   auto variableFuture =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean);
 
@@ -815,7 +815,7 @@ TEST(VARIABLEDATA, TESTCONSTRUCTION) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLEDATA, WRITECHUNKEDDATA) {
+TEST(VariableData, writeChunkedData) {
   auto result =
       mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).result();
 
@@ -841,7 +841,7 @@ TEST(VARIABLEDATA, WRITECHUNKEDDATA) {
   std::filesystem::remove_all("name");
 }
 
-TEST(VARIABLEDATA, INMEMORYEDITS) {
+TEST(VariableData, inMemoryEdits) {
   auto json = PopulateStore(json_good).value();
   auto variableObject = mdio::Variable<>::Open(json).result();
   EXPECT_TRUE(variableObject.ok());
@@ -884,7 +884,7 @@ TEST(VARIABLEDATA, INMEMORYEDITS) {
   EXPECT_TRUE(slicedVariableDataObject.status().ok());
 }
 
-TEST(VARIABLEDATA, CHECKINMEMEDIT) {
+TEST(VariableData, checkInMemoryEdits) {
   auto json = PopulateStore(json_good).value();
   auto variableObject = mdio::Variable<>::Open(json).result();
   EXPECT_TRUE(variableObject.ok());
@@ -921,7 +921,7 @@ TEST(VARIABLEDATA, CHECKINMEMEDIT) {
   // EXPECT_EQ(uncastedData[0][99], 99);
 }
 
-TEST(VARIABLEDATA, NOORIGINSLICE) {
+TEST(VariableData, nonOriginSlice) {
   auto json = PopulateStore(json_good).value();
   auto variableObject = mdio::Variable<>::Open(json).result();
   EXPECT_TRUE(variableObject.ok());
@@ -944,7 +944,7 @@ TEST(VARIABLEDATA, NOORIGINSLICE) {
   EXPECT_EQ(data[1111], -14935);
 }
 
-TEST(VARIABLEDATA, WRITETEST) {
+TEST(VariableData, writeTest) {
   auto json = PopulateStore(json_good).value();
   auto variableObject = mdio::Variable<>::Open(json).result();
   EXPECT_TRUE(variableObject.ok());

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -255,8 +255,10 @@ TEST(VariableData, fromVariable2) {
   auto data = variable_data->get_data_accessor();
 
   data({0, 0}) = 100;
-  EXPECT_EQ(data({0, 0}), 100) << "Data at 0,0 should be 100 but was " << data({0, 0});
-  EXPECT_EQ(data({1, 0}), 0) << "Data at 1,0 should be 0 but was " << data({1, 0});
+  EXPECT_EQ(data({0, 0}), 100)
+      << "Data at 0,0 should be 100 but was " << data({0, 0});
+  EXPECT_EQ(data({1, 0}), 0)
+      << "Data at 1,0 should be 0 but was " << data({1, 0});
 }
 
 TEST(Variable, context) {

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -225,9 +225,10 @@ TEST(VariableData, fromVariable) {
   ASSERT_TRUE(variable_data->longName == variable->get_long_name());
 
   auto data = variable_data->get_data_accessor();
-  // FIXME = complete test case.
+
   data({0, 0}) = 100;
-  std::cout << data({0, 0}) << "\t" << data({1, 0}) << std::endl;
+  EXPECT_EQ(data({0, 0}), 100);
+  EXPECT_EQ(data({1, 0}), 0);
 
   auto _variable_data = mdio::from_variable(variable.value());
 
@@ -252,9 +253,10 @@ TEST(VariableData, fromVariable2) {
   ASSERT_TRUE(variable_data->longName == variable->get_long_name());
 
   auto data = variable_data->get_data_accessor();
-  // FIXME = complete test case.
+
   data({0, 0}) = 100;
-  std::cout << data({0, 0}) << "\t" << data({1, 0}) << std::endl;
+  EXPECT_EQ(data({0, 0}), 100) << "Data at 0,0 should be 100 but was " << data({0, 0});
+  EXPECT_EQ(data({1, 0}), 0) << "Data at 1,0 should be 0 but was " << data({1, 0});
 }
 
 TEST(Variable, context) {
@@ -420,17 +422,27 @@ TEST(Variable, openMetadata) {
 
   auto zarr_metadata = tensorstore::internal_zarr::ZarrMetadata::FromJson(json);
 
-  std::cout << ::nlohmann::json(*zarr_metadata) << std::endl;
-
-  /*
-  partial_metadata.fill_value = std::nullptr_t;
-
-  std::cout << metadata << std::endl;
-
-  auto x = ZarrMetadata::FromJson(metadata);
-  std::cout << "HERE\n";
-  std::cout << ::nlohmann::json(x.value()) << std::endl;
-  */
+  std::string expectedString = R"(
+  {
+    "chunks":[100,50],
+    "compressor": {
+      "blocksize":0,
+      "clevel":5,
+      "cname":"lz4",
+      "id":"blosc",
+      "shuffle":-1
+      },
+    "dimension_separator":"/",
+    "dtype":"<i2",
+    "fill_value":null,
+    "filters":null,
+    "order":"C",
+    "shape":[500,500],
+    "zarr_format":2
+  })";
+  nlohmann::json expected = nlohmann::json::parse(expectedString);
+  nlohmann::json actual = nlohmann::json(*zarr_metadata);
+  EXPECT_EQ(actual, expected) << "Metadata did not match expected";
 }
 
 TEST(Variable, openExisting) {

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -199,18 +199,6 @@ TEST(VariableData, conversion) {
   EXPECT_EQ("name", variable_c.variableName);
 }
 
-TEST(Variable, conversion) {
-  // we need to be able to cast to void
-  using int16_t = mdio::dtypes::int16_t;
-  // Can convert this
-  mdio::Variable<int16_t> variable_a;
-  mdio::Variable variable_b(variable_a);
-
-  // can't do this
-  // mdio::Variable<> variable_c;
-  // mdio::Variable<int16_t> variable_d(variable_c);
-}
-
 TEST(VariableData, fromVariable) {
   using int16_t = mdio::dtypes::int16_t;
 


### PR DESCRIPTION
Cleaned up unit tests.
 - Made name case consistent.
 - Removed extraneous prints and manual checking.
 - Resolved most TODO's.