### PR TITLE
CICD build

### DIFF
--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -3,7 +3,7 @@ name: C/C++ build
 on: [push, pull_request]
 
 jobs:
-  ubuntu-build:
+  cmake_build:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -15,7 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.7
       - name: Configure and Build Project
-        uses: ilammy/setup-nasm@v1
         uses: threeal/cmake-action@main
         with:
           cxx-compiler: ${{ matrix.compiler }}

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -1,0 +1,20 @@
+name: C/C++ build
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu-build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        compiler: [g++, clang++]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Build project
+        uses: nicledomaS/cmake_build_action@v1.4
+        with:
+          cmake_args: -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+          # run_tests: ON
+          # unit_test_build: -Dtest=ON

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -10,9 +10,12 @@ jobs:
         compiler: [g++, clang++]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Setup NASM
+        uses: ilammy/setup-nasm@v1
       - name: Checkout
         uses: actions/checkout@v4.1.7
       - name: Configure and Build Project
+        uses: ilammy/setup-nasm@v1
         uses: threeal/cmake-action@main
         with:
           cxx-compiler: ${{ matrix.compiler }}

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v4.1.7
       - name: Configure and Build Project
         uses: threeal/cmake-action@main
         with:

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -6,7 +6,7 @@ jobs:
   cmake_build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # [ubuntu-latest, macos-latest]
         compiler: [g++, clang++]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cmake_build.yaml
+++ b/.github/workflows/cmake_build.yaml
@@ -12,9 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0
-      - name: Build project
-        uses: nicledomaS/cmake_build_action@v1.4
+      - name: Configure and Build Project
+        uses: threeal/cmake-action@main
         with:
-          cmake_args: -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
-          # run_tests: ON
-          # unit_test_build: -Dtest=ON
+          cxx-compiler: ${{ matrix.compiler }}


### PR DESCRIPTION
Resolves #11  adds build automation for:

- ubuntu-latest with gcc
- ubuntu-latest with clang

Build failed with macos-latest.  This depends on #52 