### PR TITLE
Add source directory guard for setting internal deps variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,20 +91,23 @@ list(APPEND mdio_TEST_COPTS
     "-Wno-unknown-warning-option")
 
 # Define the internal dependencies that should be linked
-set(mdio_INTERNAL_DEPS
-  tensorstore::driver_array
-  tensorstore::driver_zarr
-  tensorstore::driver_json
-  tensorstore::kvstore_file
-  tensorstore::kvstore_memory
-  tensorstore::tensorstore
-  tensorstore::index_space_dim_expression
-  tensorstore::index_space_index_transform
-  tensorstore::util_status_testutil
-  tensorstore::kvstore_gcs
-  tensorstore::driver_array
-  PARENT_SCOPE
-)
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  # This is not the top-level project
+  set(mdio_INTERNAL_DEPS
+    tensorstore::driver_array
+    tensorstore::driver_zarr
+    tensorstore::driver_json
+    tensorstore::kvstore_file
+    tensorstore::kvstore_memory
+    tensorstore::tensorstore
+    tensorstore::index_space_dim_expression
+    tensorstore::index_space_index_transform
+    tensorstore::util_status_testutil
+    tensorstore::kvstore_gcs
+    tensorstore::driver_array
+    PARENT_SCOPE
+  )
+endif()
 
 
 list(APPEND mdio_COMMON_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Resolves #74 
- Adds guard for setting `mdio_INTERNAL_DEPS` variable in the parent CMake.

This will likely end up generating a merge conflict if/when #72 gets merged.
I will resolve when this happens.