### PR TITLE
Fixes to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,6 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,18 +107,19 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     tensorstore::driver_array
     PARENT_SCOPE
   )
+  
+  # Define internal deps for cloud specific drivers
+  set(mdio_INTERNAL_GCS_DRIVER_DEPS
+    tensorstore::kvstore_gcs
+    PARENT_SCOPE  
+  )
+  
+  set(mdio_INTERNAL_S3_DRIVER_DEPS
+    tensorstore::kvstore_s3
+    PARENT_SCOPE
+  )
 endif()
 
-# Define internal deps for cloud specific drivers
-set(mdio_INTERNAL_GCS_DRIVER_DEPS
-  tensorstore::kvstore_gcs
-  PARENT_SCOPE  
-)
-
-set(mdio_INTERNAL_S3_DRIVER_DEPS
-  tensorstore::kvstore_s3
-  PARENT_SCOPE
-)
 
 list(APPEND mdio_COMMON_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,9 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
     tensorstore::util_status_testutil
-    tensorstore::kvstore_gcs
-    tensorstore::driver_array
     PARENT_SCOPE
   )
-  
+
   # Define internal deps for cloud specific drivers
   set(mdio_INTERNAL_GCS_DRIVER_DEPS
     tensorstore::kvstore_gcs

--- a/mdio/CMakeLists.txt
+++ b/mdio/CMakeLists.txt
@@ -100,7 +100,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -124,7 +123,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -148,7 +146,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -185,7 +182,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -208,7 +204,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -231,7 +226,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -254,7 +248,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -276,7 +269,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform
@@ -300,7 +292,6 @@ mdio_cc_test(
     tensorstore::driver_zarr
     tensorstore::driver_json
     tensorstore::kvstore_file
-    tensorstore::kvstore_memory
     tensorstore::tensorstore
     tensorstore::index_space_dim_expression
     tensorstore::index_space_index_transform


### PR DESCRIPTION
- Relocate cloud driver variables to be encapsulated in the parent scope guard.
- Remove unused memory driver from link list.