### PR TITLE
91 stats json error

### DIFF
--- a/mdio/stats.h
+++ b/mdio/stats.h
@@ -261,6 +261,14 @@ class SummaryStats {
       return histRes.status();
     }
     auto histogram = std::move(histRes.value());
+    const std::array<std::string, 5> keys = {"count", "max", "min", "sum",
+                                             "sumSquares"};
+    for (const auto& key : keys) {
+      if (!j.contains(key)) {
+        return absl::InvalidArgumentError(
+            "Error parsing statsV1:\n\tMissing key: '" + key + "'");
+      }
+    }
     auto stats =
         SummaryStats(j["count"].get<int32_t>(), j["max"].get<float>(),
                      j["min"].get<float>(), j["sum"].get<float>(),

--- a/mdio/stats_test.cc
+++ b/mdio/stats_test.cc
@@ -117,6 +117,19 @@ TEST(SummaryStatsTest, fromJsonInt) {
   EXPECT_EQ(stats.getBindable(), expected);
 }
 
+TEST(SummaryStatsTest, fromJsonMissing) {
+  nlohmann::json expected = {
+      {"count", 100},
+      {"min", -1000.0},
+      // {"max", 1000.0},  // User forgot to add max field (required)
+      {"sum", 0.0},
+      {"sumSquares", 0.0},
+      {"histogram", {{"binCenters", {1.0, 2.0, 3.0}}, {"counts", {1, 2, 3}}}}};
+  auto statsRes = mdio::internal::SummaryStats::FromJson(expected);
+  std::cout << statsRes.status() << std::endl;
+  ASSERT_FALSE(statsRes.status().ok()) << statsRes.status();
+}
+
 TEST(UserAttributesTest, fromJsonNoStats) {
   nlohmann::json expected = {{"attributes",
                               {{"foo", "bar"},

--- a/mdio/stats_test.cc
+++ b/mdio/stats_test.cc
@@ -126,7 +126,6 @@ TEST(SummaryStatsTest, fromJsonMissing) {
       {"sumSquares", 0.0},
       {"histogram", {{"binCenters", {1.0, 2.0, 3.0}}, {"counts", {1, 2, 3}}}}};
   auto statsRes = mdio::internal::SummaryStats::FromJson(expected);
-  std::cout << statsRes.status() << std::endl;
   ASSERT_FALSE(statsRes.status().ok()) << statsRes.status();
 }
 


### PR DESCRIPTION
Resolves #91 
Fixed case where missing statsV1 child keys raised a fatal assertion error.
Updated stats to use `mdio` namespace over `tensorstore`.