### PR TITLE
Variable level vector based slicing

### DIFF
--- a/mdio/dataset.h
+++ b/mdio/dataset.h
@@ -605,7 +605,7 @@ class Dataset {
    * Limited to `internal::kMaxNumSlices` slices which may not be equal to the
    * number of descriptors.
    */
-  Result<Dataset> call_isel_with_vector(
+  Result<Dataset> isel(
       const std::vector<RangeDescriptor<Index>>& slices) {
     if (slices.empty()) {
       return absl::InvalidArgumentError("No slices provided.");
@@ -837,7 +837,7 @@ class Dataset {
       // The map 'label_to_indices' is now populated with all the relevant
       // indices. You can now proceed with further processing based on this map.
 
-      return call_isel_with_vector(slices);
+      return isel(slices);
     } else if constexpr ((std::is_same_v</*NOLINT: readability/braces*/
                                          Descriptors,
                                          ListDescriptor<
@@ -867,7 +867,7 @@ class Dataset {
       // The map 'label_to_indices' is now populated with all the relevant
       // indices. You can now proceed with further processing based on this map.
 
-      return call_isel_with_vector(slices);
+      return isel(slices);
     } else {
       std::map<std::string_view, std::pair<Index, Index>>
           label_to_range;  // pair.first = start, pair.second = stop
@@ -964,7 +964,7 @@ class Dataset {
             "No slices could be made from the given descriptors.");
       }
 
-      return call_isel_with_vector(slices);
+      return isel(slices);
     }
 
     return absl::OkStatus();

--- a/mdio/dataset.h
+++ b/mdio/dataset.h
@@ -605,8 +605,7 @@ class Dataset {
    * Limited to `internal::kMaxNumSlices` slices which may not be equal to the
    * number of descriptors.
    */
-  Result<Dataset> isel(
-      const std::vector<RangeDescriptor<Index>>& slices) {
+  Result<Dataset> isel(const std::vector<RangeDescriptor<Index>>& slices) {
     if (slices.empty()) {
       return absl::InvalidArgumentError("No slices provided.");
     }

--- a/mdio/dataset.h
+++ b/mdio/dataset.h
@@ -43,9 +43,6 @@
 namespace mdio {
 namespace internal {
 
-// Gets set by -DMAX_NUM_SLICES cmake flag or defaults to 32
-constexpr std::size_t kMaxNumSlices = MAX_NUM_SLICES;
-
 /**
  * @brief Retrieves the .zarray JSON metadata from the given `metadata`.
  *

--- a/mdio/impl.h
+++ b/mdio/impl.h
@@ -135,6 +135,8 @@ constexpr auto kByte = tensorstore::dtype_v<mdio::dtypes::byte_t>;
 namespace internal {
 // Gets set by -DMAX_NUM_SLICES cmake flag or defaults to 32
 constexpr std::size_t kMaxNumSlices = MAX_NUM_SLICES;
+constexpr std::string_view kInertSliceKey =
+    "MDIO_INERT_SLICE_KEY_CONSTANT_NO_USE";
 }  // namespace internal
 
 }  // namespace mdio

--- a/mdio/impl.h
+++ b/mdio/impl.h
@@ -132,6 +132,11 @@ constexpr auto kComplex128 = tensorstore::dtype_v<mdio::dtypes::complex128_t>;
 constexpr auto kByte = tensorstore::dtype_v<mdio::dtypes::byte_t>;
 }  // namespace constants
 
+namespace internal {
+// Gets set by -DMAX_NUM_SLICES cmake flag or defaults to 32
+constexpr std::size_t kMaxNumSlices = MAX_NUM_SLICES;
+}  // namespace internal
+
 }  // namespace mdio
 
 #endif  // MDIO_IMPL_H_

--- a/mdio/variable.h
+++ b/mdio/variable.h
@@ -194,9 +194,6 @@ struct extract_descriptor_Ttype<T&&> {
 
 namespace internal {
 
-constexpr std::string_view kInertSliceKey =
-    "MDIO_INERT_SLICE_KEY_CONSTANT_NO_USE";
-
 /**
  * @brief Checks a status for a missing driver message and returns an MDIO
  * specific error message.

--- a/mdio/variable.h
+++ b/mdio/variable.h
@@ -928,7 +928,7 @@ class Variable {
   template <size_t... I>
   struct make_index_sequence<0, I...> : index_sequence<I...> {};
 
-  template<std::size_t... I>
+  template <std::size_t... I>
   Result<Variable> call_slice_with_vector_impl(
       const std::vector<RangeDescriptor<Index>>& slices,
       std::index_sequence<I...>) {
@@ -936,12 +936,12 @@ class Variable {
   }
 
   /**
-   * @brief An overload of the `slice` method that takes a vector of RangeDescriptors.
-   * This method is limited to `internal::kMaxNumSlices` slices.
-   * This overload should only ever be used when a runtime number of slices must be generated.
-  */
-  Result<Variable> slice(
-      const std::vector<RangeDescriptor<Index>>& slices) {
+   * @brief An overload of the `slice` method that takes a vector of
+   * RangeDescriptors. This method is limited to `internal::kMaxNumSlices`
+   * slices. This overload should only ever be used when a runtime number of
+   * slices must be generated.
+   */
+  Result<Variable> slice(const std::vector<RangeDescriptor<Index>>& slices) {
     if (slices.empty()) {
       return absl::InvalidArgumentError("No slices provided.");
     }
@@ -956,13 +956,13 @@ class Variable {
     }
 
     std::vector<RangeDescriptor<Index>> slicesCopy = slices;
-    for (int i=slices.size(); i<internal::kMaxNumSlices; ++i) {
+    for (int i = slices.size(); i < internal::kMaxNumSlices; ++i) {
       slicesCopy.emplace_back(
-        RangeDescriptor<Index>({internal::kInertSliceKey, 0, 1, 1}));
+          RangeDescriptor<Index>({internal::kInertSliceKey, 0, 1, 1}));
     }
 
-    return call_slice_with_vector_impl(slicesCopy,
-                                       std::make_index_sequence<internal::kMaxNumSlices>{});
+    return call_slice_with_vector_impl(
+        slicesCopy, std::make_index_sequence<internal::kMaxNumSlices>{});
   }
 
   /**

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -555,8 +555,7 @@ TEST(Variable, sliceVector) {
   // compile time example
   mdio::RangeDescriptor<mdio::Index> desc1 = {"x", 0, 5, 1};
   mdio::RangeDescriptor<mdio::Index> desc2 = {"y", 5, 11, 1};
-  std::vector<mdio::RangeDescriptor<mdio::Index>> descriptors = {desc1,
-                                                                  desc2};
+  std::vector<mdio::RangeDescriptor<mdio::Index>> descriptors = {desc1, desc2};
 
   auto result = variable.slice(descriptors);
   ASSERT_TRUE(result.ok());
@@ -591,7 +590,7 @@ TEST(Variable, sliceOverfullVector) {
   // compile time example
   mdio::RangeDescriptor<mdio::Index> desc1 = {"x", 0, 5, 1};
   std::vector<mdio::RangeDescriptor<mdio::Index>> descriptors;
-  for (int i=0; i<33; ++i) {
+  for (int i = 0; i < 33; ++i) {
     descriptors.push_back(desc1);
   }
 

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -548,6 +548,59 @@ TEST(Variable, slice) {
   std::filesystem::remove_all("name");
 }
 
+TEST(Variable, sliceVector) {
+  auto variable =
+      mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).value();
+
+  // compile time example
+  mdio::RangeDescriptor<mdio::Index> desc1 = {"x", 0, 5, 1};
+  mdio::RangeDescriptor<mdio::Index> desc2 = {"y", 5, 11, 1};
+  std::vector<mdio::RangeDescriptor<mdio::Index>> descriptors = {desc1,
+                                                                  desc2};
+
+  auto result = variable.slice(descriptors);
+  ASSERT_TRUE(result.ok());
+
+  auto domain = result->dimensions();
+
+  EXPECT_THAT(domain.labels(), ::testing::ElementsAre("x", "y"));
+
+  EXPECT_THAT(domain.origin(), ::testing::ElementsAre(0, 5));
+
+  EXPECT_THAT(domain.shape(), ::testing::ElementsAre(5, 6));
+
+  std::filesystem::remove_all("name");
+}
+
+TEST(Variable, sliceEmptyVector) {
+  auto variable =
+      mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).value();
+
+  std::vector<mdio::RangeDescriptor<mdio::Index>> descriptors;
+
+  auto result = variable.slice(descriptors);
+  ASSERT_FALSE(result.ok());
+
+  std::filesystem::remove_all("name");
+}
+
+TEST(Variable, sliceOverfullVector) {
+  auto variable =
+      mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean).value();
+
+  // compile time example
+  mdio::RangeDescriptor<mdio::Index> desc1 = {"x", 0, 5, 1};
+  std::vector<mdio::RangeDescriptor<mdio::Index>> descriptors;
+  for (int i=0; i<33; ++i) {
+    descriptors.push_back(desc1);
+  }
+
+  auto result = variable.slice(descriptors);
+  ASSERT_FALSE(result.ok());
+
+  std::filesystem::remove_all("name");
+}
+
 TEST(Variable, labeledArray) {
   auto dimensions = tensorstore::Box({0, 0, 0}, {100, 200, 300});
 


### PR DESCRIPTION
Resolves #107 
# Introduces
- An overload for `Variable.slice` which accepts a compile time limited number of elements. This allows for more dynamic runtime slicing.
- Renamed `Dataset.call_isel_with_vector()` to `Dataset.isel()` to provide sensible named overload.
# Lacks
- VariableData vector slicing. Implementing an overload 