### PR TITLE
Make Read async

### DIFF
--- a/mdio/variable.h
+++ b/mdio/variable.h
@@ -788,19 +788,27 @@ class Variable {
   template <ArrayOriginKind OriginKind = offset_origin>
   Future<VariableData<T, R, OriginKind>> Read() {
     auto data = tensorstore::Read(store);
+    // Capture the metadata to avoid shared_ptr issues
+    auto meta = getMetadata();
+    std::string vName = variableName;
+    std::string lName = longName;
+    auto dims = dimensions();
     auto pair =
         tensorstore::PromiseFuturePair<VariableData<T, R, OriginKind>>::Make();
+    // TODO(BrianMichell): If the Variable goes out of scope before the promise completes a segfault will occur due to the shared_ptr metadata
     data.ExecuteWhenReady(
-        [this, promise = pair.promise](
+        [meta, vName, lName, dims, attributes_ptr = this->attributes, promise = pair.promise](
             tensorstore::ReadyFuture<SharedArray<T, R, OriginKind>> readyFut) {
+          // We capture the attribures to ensure the refcount is correct.
+          // If the Variable goes out of scope before the promise completes a segcault will occur.
           auto ready_result = readyFut.result();
           if (!ready_result.ok()) {
             promise.SetResult(ready_result.status());
           } else {
-            LabeledArray<T, R, OriginKind> labeledArray{this->dimensions(),
+            LabeledArray<T, R, OriginKind> labeledArray{dims,
                                                         ready_result.value()};
             VariableData<T, R, OriginKind> variableData{
-                this->variableName, this->longName, this->getMetadata(),
+                vName, lName, meta,
                 labeledArray};
             promise.SetResult(variableData);
           }


### PR DESCRIPTION
Resolves #112 
Removes the blocking operation inside the `Variable.Read()` method and properly sets up the promise/future pair.
