### PR TITLE
Resolve unclear failure opening v0 datasets

### DIFF
--- a/examples/real_data_example/CMakeLists.txt
+++ b/examples/real_data_example/CMakeLists.txt
@@ -32,6 +32,6 @@ target_link_libraries(real_data_example PRIVATE
   mdio
   ${mdio_INTERNAL_DEPS}
   ${mdio_INTERNAL_S3_DRIVER_DEPS}
-  PNG::PNG
+  ${mdio_INTERNAL_GCS_DRIVER_DEPS}
   indicators
 )

--- a/examples/real_data_example/README.md
+++ b/examples/real_data_example/README.md
@@ -32,7 +32,7 @@ This tool allows users to extract specific slices from 3D seismic data stored in
 - `--xline_range`: Crossline range in format {crossline,start,end,step} (default: "{crossline,500,700,1}")
 - `--depth_range`: Optional depth range in format {depth,start,end,step}
 - `--variable_name`: Name of the seismic variable to extract (default: "seismic")
-- `--print_dataset`: Print the dataset URL and return without processing
+- `--print_dataset`: Print the dataset metadata and return without processing
 
 ### Example
 

--- a/examples/real_data_example/src/real_data_example.cc
+++ b/examples/real_data_example/src/real_data_example.cc
@@ -38,7 +38,7 @@ ABSL_FLAG(std::string, depth_range, "",
           "Optional depth range in format {depth,start,end,step}");
 ABSL_FLAG(std::string, variable_name, "seismic",
           "Name of the seismic variable");
-ABSL_FLAG(bool, print_dataset, false, "Print the dataset URL and return");
+ABSL_FLAG(bool, print_dataset, false, "Print the dataset metadata and return");
 ABSL_FLAG(std::string, dataset_path,
           "s3://tgs-opendata-poseidon/full_stack_agc.mdio",
           "The path to the dataset");

--- a/examples/real_data_example/src/real_data_example.cc
+++ b/examples/real_data_example/src/real_data_example.cc
@@ -125,5 +125,11 @@ int main(int argc, char* argv[]) {
   auto desc2 = ParseRange(crossline_range);
   auto desc3 = ParseRange(depth_range);
 
-  return Run<float>(desc1, desc2, desc3).ok() ? 0 : 1;
+  auto runResult = Run<float>(desc1, desc2, desc3);
+  if (!runResult.ok()) {
+    std::cerr << "Error: " << runResult.ToString() << std::endl;
+    return 1;
+  }
+
+  return 0;
 }

--- a/examples/real_data_example/src/real_data_example.cc
+++ b/examples/real_data_example/src/real_data_example.cc
@@ -24,7 +24,6 @@
 #include "interpolation.h"
 #include "progress.h"
 #include "seismic_numpy.h"
-#include "seismic_png.h"
 #include "tensorstore/tensorstore.h"
 
 #define MDIO_RETURN_IF_ERROR(...) TENSORSTORE_RETURN_IF_ERROR(__VA_ARGS__)

--- a/mdio/dataset.h
+++ b/mdio/dataset.h
@@ -1100,6 +1100,15 @@ class Dataset {
     all_done_future.ExecuteWhenReady(
         [promise = std::move(pair.promise), variables = std::move(variables),
          metadata](tensorstore::ReadyFuture<void> readyFut) {
+          if (metadata.contains("api_version") &&
+              !metadata.contains("apiVersion")) {
+            promise.SetResult(
+                absl::Status(absl::StatusCode::kInvalidArgument,
+                             "Detected MDIO v0 dataset model " +
+                                 metadata["api_version"].get<std::string>() +
+                                 " but expected v1"));
+            return;
+          }
           mdio::VariableCollection collection;
           mdio::coordinate_map coords;
           std::unordered_map<std::string, Index> shape_size;

--- a/mdio/dataset_test.cc
+++ b/mdio/dataset_test.cc
@@ -1073,4 +1073,42 @@ TEST(Dataset, kCreateOverExisting) {
          "one without error!";
 }
 
+TEST(Dataset, mockV0) {
+  // TODO(BriaMich): Update this test to do a full mock of the v0 dataset schema
+  std::string path = "zarrs/acceptance";
+
+  // Build a v1 Dataset on disk
+  auto json_vars = GetToyExample();
+  auto datasetRes =
+      mdio::Dataset::from_json(json_vars, path, mdio::constants::kCreateClean);
+  ASSERT_TRUE(datasetRes.status().ok()) << datasetRes.status();
+
+  auto dataset = datasetRes.value();
+
+  // Update the api version metadata to follow the v0 standard
+  const nlohmann::json& immutable_metadata = dataset.getMetadata();
+  nlohmann::json& mutable_metadata =
+      const_cast<nlohmann::json&>(immutable_metadata);
+  mutable_metadata["api_version"] = "0.8.3";
+  mutable_metadata.erase("apiVersion");
+
+  // Do an on-disk manipulation of the v1 dataset
+  // We also need to make an update to a Variable's metadata
+  // This is an unsafe workaround to mutate the Dataset's metadata
+  nlohmann::json attrs = {{"foo", "bar"}};
+  auto varRes = dataset.get_variable("image");
+  ASSERT_TRUE(varRes.ok()) << varRes.status();
+  auto var = varRes.value();
+  auto varUpdateRes = var.UpdateAttributes<>(attrs);
+  ASSERT_TRUE(varUpdateRes.status().ok()) << varUpdateRes.status();
+
+  auto commitFut = dataset.CommitMetadata();
+  ASSERT_TRUE(commitFut.status().ok()) << commitFut.status();
+
+  auto reopenedDsFut = mdio::Dataset::Open(path, mdio::constants::kOpen);
+  ASSERT_FALSE(reopenedDsFut.status().ok())
+      << "Opened a v0 dataset without error!" << std::endl
+      << reopenedDsFut.value();
+}
+
 }  // namespace


### PR DESCRIPTION
Resolves #147 
- Fixes compilation of `real_data_example`
- Adds error message display on failure.
- Adds clear error message for opening legacy datasets.