### PR TITLE
Documentation fixes

### DIFF
--- a/mdio/dataset.h
+++ b/mdio/dataset.h
@@ -450,6 +450,13 @@ class Dataset {
     return variables.get<T, R, M>(variable_name);
   }
 
+  /**
+   * @brief Gets the intervals of the the dataset.
+   * @param 0 or more dimension labels for the intervals to retrieve.
+   * No labels will return all intervals in the dataset.
+   * @return A vector of intervals or NotFoundError if no intervals could be
+   * found.
+   */
   template <typename... DimensionIdentifier>
   mdio::Result<std::vector<Variable<>::Interval>> get_intervals(
       const DimensionIdentifier&... labels) const {
@@ -604,7 +611,9 @@ class Dataset {
 
   // Wrapper function that generates the index sequence
   /**
-   * @brief Internal use only.
+   * @brief This version of isel is only expected to be used interally.
+   * Documentation is provided for clarity and usage in the case where
+   * the number of descriptors cannot be known at compile time.
    * Calls the `isel` method with a vector of `RangeDescriptor` objects.
    * Limited to `internal::kMaxNumSlices` slices which may not be equal to the
    * number of descriptors.
@@ -1296,6 +1305,11 @@ class Dataset {
     return pair.future;
   }
 
+  /**
+   * @brief Commits changes made to the Variables metadata to durable media.
+   * @return A future representing the completion of the commit or an error if
+   * no changes were made but the commit was requested.
+   */
   tensorstore::Future<void> CommitMetadata() {
     auto keys = variables.get_iterable_accessor();
 
@@ -1414,19 +1428,23 @@ class Dataset {
     return pair.future;
   }
 
+  /**
+   * @brief Gets the Dataset level metadata.
+   * @return A const reference to the Dataset's metadata.
+   */
   const nlohmann::json& getMetadata() const { return metadata; }
 
-  // variables contained in the dataset
+  /// variables contained in the dataset
   VariableCollection variables;
 
-  // link a variable name to its coordinates via its name(s)
+  /// link a variable name to its coordinates via its name(s)
   coordinate_map coordinates;
 
-  // enumerate the dimensions
+  /// enumerate the dimensions
   tensorstore::IndexDomain<> domain;
 
  private:
-  // the metadata associated with the dataset (root .zattrs)
+  /// the metadata associated with the dataset (root .zattrs)
   ::nlohmann::json metadata;
 };
 }  // namespace mdio

--- a/mdio/impl.h
+++ b/mdio/impl.h
@@ -114,7 +114,7 @@ constexpr auto kCreateClean =
 /// Create a new file or error if it already exists.
 constexpr auto kCreate = tensorstore::OpenMode::create;
 
-// Tensorstore appears to be imposing a max size of 0x3fffffffffffffff
+/// Tensorstore appears to be imposing a max size of 0x3fffffffffffffff
 constexpr uint64_t kMaxSize = 4611686018427387903;
 
 // Supported dtypes

--- a/mdio/stats.h
+++ b/mdio/stats.h
@@ -51,14 +51,15 @@
  *
  * @code
  * // NOTE: We do not verify the status of `dataset.variables.at("variable")` in
- * this example code. This is for brevity. mdio::UserAttributes userAttrs =
- * dataset.variables.at("variable").value().userAttrs; nlohmann::json
- * updatedAttrs = userAttrs.ToJson();
+ * this example code. This is for brevity.
+ * mdio::UserAttributes userAttrs =
+ *                         dataset.variables.at("variable").value().userAttrs;
+ * nlohmann::json updatedAttrs = userAttrs.ToJson();
  * // Modify updatedAttrs as any normal JSON object
  * // NOTE: FromJson can take an optional template of `int32_t` default to
- * `float` to specify the type of the histogram. auto updatedUserAttrsResult =
- * mdio::UserAttributes::FromJson(updatedAttrs); if
- * (!updatedUserAttrsResult.ok()) {
+ * `float` to specify the type of the histogram.
+ * auto updatedUserAttrsResult = mdio::UserAttributes::FromJson(updatedAttrs);
+ * if (!updatedUserAttrsResult.ok()) {
  *   // Handle error
  * }
  * mdio::UserAttributes updatedUserAttrs = updatedUserAttrsResult.value();
@@ -343,8 +344,9 @@ class UserAttributes {
    * @note This constructor is intended for internal use only. Please use the
    * static member function `FromJson(nlohmann::json)`
    * @code
-   * auto attrs = UserAttributes::FromJson(j).value(); // j is some valid
-   * nlohmann::json object nlohmann::json newAttrs = attrs.ToJson();
+   * // j is some valid nlohmann::json object
+   * auto attrs = UserAttributes::FromJson(j).value();
+   * nlohmann::json newAttrs = attrs.ToJson();
    * newAttrs["attributes"]["newKey"] = "newValue";
    * auto newAttrsRes = UserAttributes::FromJson(newAttrs).value();
    * @endcode


### PR DESCRIPTION
Some of the documentation, namely the code examples, got mangled by clang-format. This corrects those.

There were also some functions and member data that were lacking.