### PR TITLE
Statically build+link example with open data access 

### DIFF
--- a/examples/seismic_reader/CMakeLists.txt
+++ b/examples/seismic_reader/CMakeLists.txt
@@ -1,0 +1,97 @@
+cmake_minimum_required(VERSION 3.24)
+project(SeismicReader VERSION 1.0.0 LANGUAGES CXX)
+
+# Set the C++ standard to C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Specify MDIO installation directory (set by bootstrap.sh)
+set(MDIO_INSTALL_DIR "${CMAKE_SOURCE_DIR}/inst")
+
+# Add library directories
+link_directories(
+    ${MDIO_INSTALL_DIR}/lib
+    ${MDIO_INSTALL_DIR}/lib/drivers
+)
+
+# CURL is built and installed by the MDIO installer; no need for separate find_package.
+
+# Define MDIO linker flags - corrected format to match SCons configuration
+set(MDIO_LINK_FLAGS
+    "-Wl,-rpath,${MDIO_INSTALL_DIR}/lib,-rpath,${MDIO_INSTALL_DIR}/lib/drivers,--whole-archive,-L${MDIO_INSTALL_DIR}/lib,-L${MDIO_INSTALL_DIR}/lib/drivers,\
+-lnlohmann_json_schema_validator,\
+-ltensorstore_driver_zarr_bzip2_compressor,\
+-ltensorstore_driver_zarr_driver,\
+-ltensorstore_driver_zarr_spec,\
+-ltensorstore_driver_zarr_zlib_compressor,\
+-ltensorstore_driver_zarr_zstd_compressor,\
+-ltensorstore_driver_zarr_blosc_compressor,\
+-ltensorstore_kvstore_gcs_http,\
+-ltensorstore_kvstore_gcs_gcs_resource,\
+-ltensorstore_kvstore_gcs_validate,\
+-ltensorstore_kvstore_gcs_http_gcs_resource,\
+-ltensorstore_kvstore_s3,\
+-ltensorstore_kvstore_s3_aws_credentials_resource,\
+-ltensorstore_kvstore_s3_credentials_default_credential_provider,\
+-ltensorstore_kvstore_s3_credentials_environment_credential_provider,\
+-ltensorstore_kvstore_s3_credentials_file_credential_provider,\
+-ltensorstore_kvstore_s3_credentials_ec2_credential_provider,\
+-ltensorstore_kvstore_s3_s3_metadata,\
+-ltensorstore_kvstore_s3_s3_resource,\
+-ltensorstore_driver_json,\
+-ltensorstore_internal_cache_cache_pool_resource,\
+-ltensorstore_internal_data_copy_concurrency_resource,\
+-ltensorstore_kvstore_file,\
+-ltensorstore_internal_file_io_concurrency_resource,\
+-ltensorstore_internal_cache_kvs_backed_chunk_cache,\
+-labsl,\
+-lblosc,\
+-ltensorstore,\
+-lre2,\
+-lriegeli,\
+-ltinyxml2_tinyxml2,\
+-lcurl,\
+-lopenssl,\
+--no-whole-archive,\
+-lpthread,\
+-lm"
+)
+
+# Debug: Print out the MDIO_LINK_FLAGS
+message(STATUS "MDIO_LINK_FLAGS: ${MDIO_LINK_FLAGS}")
+
+# Create the executable target. (Assumes main.cpp exists in your project.)
+add_executable(read main.cc)
+
+# Append the linker flags to the target's link flags.
+set_target_properties(read PROPERTIES LINK_FLAGS "${MDIO_LINK_FLAGS}")
+
+# Add compile definitions
+target_compile_definitions(read PRIVATE HAVE_MDIO MAX_NUM_SLICES=32)
+
+# Add MDIO and third-party include directories for target 'read'
+# Collect all immediate subdirectories from the MDIO include directory.
+file(GLOB CHILD_DIRS LIST_DIRECTORIES true "${MDIO_INSTALL_DIR}/include/*")
+
+# Also include the top-level include directory so that headers like "mdio/mdio.h" are found.
+list(INSERT CHILD_DIRS 0 "${MDIO_INSTALL_DIR}/include")
+
+# Remove any unwanted directories (for example, the gtest-src directory)
+foreach(dir ${CHILD_DIRS})
+    get_filename_component(basename ${dir} NAME)
+    if(basename MATCHES "gtest-src")
+        list(REMOVE_ITEM CHILD_DIRS "${dir}")
+    endif()
+endforeach()
+
+# Append additional directories that the installer uses but might not be one-level deep.
+list(APPEND CHILD_DIRS 
+    "${MDIO_INSTALL_DIR}/include/nlohmann_json-src/include"
+    "${MDIO_INSTALL_DIR}/include/half-src/include"
+)
+
+target_include_directories(read PRIVATE ${CHILD_DIRS})
+
+# Debug: Print out the include directories for target 'read'
+get_target_property(READ_INCLUDES read INCLUDE_DIRECTORIES)
+message(STATUS "Target 'read' include directories: ${READ_INCLUDES}")

--- a/examples/seismic_reader/README.md
+++ b/examples/seismic_reader/README.md
@@ -1,0 +1,64 @@
+# Seismic data reader
+
+The purpose of this example is to demonstrate one method of integrating the **MDIO** C++ library into a seismic data reader into an existing project.
+
+Due to the variety of target build systems and differing complexities of integrating the library with existing CMake projects, this example will also expose a way to build MDIO and its dependencies as a set of shared and linkable libraries and integrate it that way.
+
+## Table of contents
+- [Concepts demonstrated](#concepts-demonstrated)
+- [Overview](#overview)
+- [Running](#running)
+- [Glossary](#glossary)
+
+## Concepts demonstrated
+- Index-based slicing
+- Value-based slicing
+- Dimension coordinates
+- Coordinates
+- Caching
+
+Chunk-aligned opreations were briefly discussed but not examined in great detail for this example.
+
+## Overview
+
+This example assumes that you are able to build the main branch of **MDIO**.
+
+This example will perform the following steps:
+
+1. Clone the installer to this directory.
+2. Run the installer, building and installing several archives and shared files.
+3. Link the installed files in the `CMakeLists.txt`.
+4. Demonstrate opening a Dataset with a configurable cache.
+5. Demonstrate acquiring the corner points for the UTM grid on the Open Poseidon dataset from S3.
+    - Calculates the latitude and longitude coordinates for the corner points.
+    - Provides a web link to display the surface area on a map.
+6. Demonstrate acquiring the inline and crossline extents.
+7. Demonstrate an index-based slice for chunk-aligned, tracewise processing.
+    - Calculates basic statistics for a small section of the dataset.
+    - Tracks the highest (peak) and lowest (trough) amplitudes and their actual inline/crossline coordinate pairs.
+8. Demonstrate a value-based slice for more targeted analysis.
+    - Corolates the cdp-x and cdp-y coordinate pair for the peak and trough values.
+    - Provides a web link to display each one's location on a map.
+
+## Running
+
+```bash
+$ ./bootstrap.sh
+$ cd build
+$ cmake ..
+$ make -j
+```
+
+The bootstrap shell script will build and install the mdio-cpp library as a set of shared and static objects.
+
+It will then set up the build directory if it completes without error.
+
+After the program has finished building it can be run with `./read`.
+
+## Glossary
+- Dimension coordinate: A 1-dimensional Variable that describes a dimension of the dataset. 
+- Coordinate: A Variable that helps describe data outside of its natural (logical) domain. May be greater than 1-dimensional.
+- Slicing: The act of subsetting a dataset along one or more dimension coordinates. A subset of a dataset is still considered a dataset.
+- Index-based slicing (*isel*): Subsetting a dataset based on the logical indices of its *dimension coordinate*(s).
+- Value-based slicing (*sel*): Subsetting a dataset based on the values contained by its *dimension coordinate*(s).
+- Chunk-aligned: Slicing the data along its logical chunk boundries for efficient I/O performance.

--- a/examples/seismic_reader/bootstrap.sh
+++ b/examples/seismic_reader/bootstrap.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# bootstrap.sh
+#
+# This script bootstraps the MDIO installation.
+# It clones the mdio-cpp-installer repository and installs MDIO
+# into the current directory (in the "inst" folder).
+#
+# Instruction from the installer:
+#   $ ./install.sh [install_directory] [mdio_tag]
+# (the mdio_tag is ignored)
+# The hidden --curl flag is also used.
+
+# Define installation directory as the "inst" folder in the current directory
+INST_DIR="$(pwd)/inst"
+
+echo "Installing MDIO in: $INST_DIR"
+
+# Clone the installer repo if it does not already exist
+if [ ! -d "mdio-cpp-installer" ]; then
+    echo "Cloning mdio-cpp-installer repository..."
+    git clone https://github.com/BrianMichell/mdio-cpp-installer.git || { 
+        echo "Failed to clone repository."; exit 1; 
+    }
+fi
+
+# Change into the installer directory
+cd mdio-cpp-installer || { 
+    echo "Failed to change directory into mdio-cpp-installer."; exit 1; 
+}
+
+# Make sure the installer script is executable
+chmod +x install.sh
+
+# Run the installer: Pass the installation directory, a dummy tag,
+# and the hidden "--curl" flag.
+echo "Running MDIO installer..."
+./install.sh "$INST_DIR" dummy_tag --curl || { 
+    echo "MDIO installation failed."; exit 1; 
+}
+
+echo "MDIO installation completed successfully."
+
+# Return to the original directory
+cd ..
+
+mkdir build

--- a/examples/seismic_reader/main.cc
+++ b/examples/seismic_reader/main.cc
@@ -1,0 +1,173 @@
+// Copyright 2025 TGS
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "main.hh"
+
+int main() {
+    const std::string path = "s3://tgs-opendata-poseidon/full_stack_agc.mdio";
+    const uint64_t cache_size_bytes = 1024ULL * 1024ULL * 1024ULL * 5ULL;  // Use a 5GiB cache.
+    mdio::Future<mdio::Dataset> dsFut = OpenDataset(path, cache_size_bytes);
+
+    if (!dsFut.status().ok()) {
+        std::cerr << "Failed to open dataset: " << dsFut.status().message() << std::endl;
+        return 1;
+    }
+
+    mdio::Dataset ds = dsFut.value();
+    std::cout << "Dataset opened successfully" << std::endl;
+    std::cout << ds << std::endl;
+
+    auto cdpsFut = GetUTMCoords(ds);
+    if (!cdpsFut.status().ok()) {
+        std::cerr << "Failed to get UTM coordinates: " << cdpsFut.status().message() << std::endl;
+        return 1;
+    }
+
+    auto cdps = cdpsFut.value();
+    auto cdp_x = cdps.first.value();
+    auto cdp_y = cdps.second.value();
+
+    auto cdp_x_extents = GetExtents<mdio::dtypes::float64_t>(cdp_x);
+    auto cdp_y_extents = GetExtents<mdio::dtypes::float64_t>(cdp_y);
+
+    std::cout << "========CDP Coordinates=========" << std::endl;
+    std::cout << "CDP X extents: " << cdp_x_extents << std::endl;
+    std::cout << "CDP Y extents: " << cdp_y_extents << std::endl;
+    utm::print_corners(cdp_x_extents, cdp_y_extents);
+    std::cout << std::endl;
+    // This displays the maximum area of the extents on a web map.
+    // The surveys actual polygon is not computed in this example.
+    utm::web_display(cdp_x_extents, cdp_y_extents);
+    std::cout << std::endl;
+    std::cout << "=================================" << std::endl << std::endl;
+
+    auto linesFut = GetInlineCrossline(ds);
+    if (!linesFut.status().ok()) {
+        std::cerr << "Failed to get inline and crossline coordinates: " << linesFut.status().message() << std::endl;
+        return 1;
+    }
+
+    auto lines = linesFut.value();
+    auto il = lines.first.value();
+    auto xl = lines.second.value();
+
+    auto il_extents = GetExtents<mdio::dtypes::uint16_t>(il);
+    auto xl_extents = GetExtents<mdio::dtypes::uint16_t>(xl);
+
+    std::cout << "Inline extents: " << il_extents << std::endl;
+    std::cout << "Crossline extents: " << xl_extents << std::endl;
+
+    auto statsResult = stats::CalculateVolumeStatistics<mdio::dtypes::float32_t, mdio::dtypes::uint16_t>(ds);
+    if (!statsResult.status().ok()) {
+        std::cerr << "Failed to get volume statistics: " << statsResult.status().message() << std::endl;
+        return 1;
+    }
+
+    auto stats = statsResult.value();
+    std::cout << stats << std::endl;
+
+    // Now that we have the statistics, lets pinpoint where our peak and trough amplitudes are located on the world.
+    mdio::ValueDescriptor<mdio::dtypes::uint16_t> il_peak = {"inline", stats.peak_amplitude_inline};
+    mdio::ValueDescriptor<mdio::dtypes::uint16_t> xl_peak = {"crossline", stats.peak_amplitude_crossline};
+    mdio::ValueDescriptor<mdio::dtypes::uint16_t> il_trough = {"inline", stats.trough_amplitude_inline};
+    mdio::ValueDescriptor<mdio::dtypes::uint16_t> xl_trough = {"crossline", stats.trough_amplitude_crossline};
+
+    auto peakSlicedDatasetRes = ds.sel(il_peak, xl_peak);
+    if (!peakSlicedDatasetRes.status().ok()) {
+        std::cerr << "Failed to slice dataset: " << peakSlicedDatasetRes.status().message() << std::endl;
+        return 1;
+    }
+
+    auto peakSlicedDataset = peakSlicedDatasetRes.value();
+    // We can print the dataset and see that the inline and crossline indices are not the same as their values.
+    // std::cout << "Peak sliced dataset: " << peakSlicedDataset << std::endl;
+
+    // We can re-use the same function (and variable) to get the cdp coordinates of the peak amplitude now.
+    cdpsFut = GetUTMCoords(peakSlicedDataset);
+    if (!cdpsFut.status().ok()) {
+        std::cerr << "Failed to get UTM coordinates of peak amplitude: " << cdpsFut.status().message() << std::endl;
+        return 1;
+    }
+
+    cdps = cdpsFut.value();
+    cdp_x = cdps.first.value();
+    cdp_y = cdps.second.value();
+    cdp_x_extents = GetExtents<mdio::dtypes::float64_t>(cdp_x);
+    cdp_y_extents = GetExtents<mdio::dtypes::float64_t>(cdp_y);
+
+    std::cout << "========Peak Amplitude=========" << std::endl;
+    utm::print_corners(cdp_x_extents, cdp_y_extents);
+    utm::web_display(cdp_x_extents, cdp_y_extents);
+    std::cout << std::endl;
+    std::cout << "=================================" << std::endl << std::endl;
+
+    auto troughSlicedDatasetRes = ds.sel(il_trough, xl_trough);
+    if (!troughSlicedDatasetRes.status().ok()) {
+        std::cerr << "Failed to slice dataset: " << troughSlicedDatasetRes.status().message() << std::endl;
+        return 1;
+    }
+
+    auto troughSlicedDataset = troughSlicedDatasetRes.value();
+    // The trough sliced dataset should show a different inline/crossline index pair than the peak sliced dataset.
+    // std::cout << "Trough sliced dataset: " << troughSlicedDataset << std::endl;
+
+    cdpsFut = GetUTMCoords(troughSlicedDataset);
+    if (!cdpsFut.status().ok()) {
+        std::cerr << "Failed to get UTM coordinates of trough amplitude: " << cdpsFut.status().message() << std::endl;
+        return 1;
+    }
+
+    cdps = cdpsFut.value();
+    cdp_x = cdps.first.value();
+    cdp_y = cdps.second.value();
+    cdp_x_extents = GetExtents<mdio::dtypes::float64_t>(cdp_x);
+    cdp_y_extents = GetExtents<mdio::dtypes::float64_t>(cdp_y);
+
+    std::cout << "========Trough Amplitude=========" << std::endl;
+    utm::print_corners(cdp_x_extents, cdp_y_extents);
+    std::cout << std::endl;
+    utm::web_display(cdp_x_extents, cdp_y_extents);
+    std::cout << std::endl;
+    std::cout << "=================================" << std::endl << std::endl;
+    return 0;
+}
+
+
+mdio::Future<mdio::Dataset> OpenDataset(const std::string& path, uint64_t cache_size_bytes) {
+    auto cacheJson = nlohmann::json::parse(R"({"cache_pool": {"total_bytes_limit": 1073741824}})");  // 1GiB default cache size.
+    cacheJson["cache_pool"]["total_bytes_limit"] = cache_size_bytes;
+    auto spec = mdio::Context::Spec::FromJson(cacheJson);
+    auto ctx = mdio::Context(spec.value());
+    return mdio::Dataset::Open(path, mdio::constants::kOpen, ctx);
+}
+
+mdio::Result<std::pair<mdio::Future<mdio::VariableData<mdio::dtypes::float64_t>>, mdio::Future<mdio::VariableData<mdio::dtypes::float64_t>>>> GetUTMCoords(mdio::Dataset& ds) {
+    MDIO_ASSIGN_OR_RETURN(auto cdp_x, ds.variables.get<mdio::dtypes::float64_t>("cdp-x"));
+    MDIO_ASSIGN_OR_RETURN(auto cdp_y, ds.variables.get<mdio::dtypes::float64_t>("cdp-y"));
+
+    auto cdp_x_fut = cdp_x.Read();
+    auto cdp_y_fut = cdp_y.Read();
+
+    return std::make_pair(cdp_x_fut, cdp_y_fut);
+}
+
+mdio::Result<std::pair<mdio::Future<mdio::VariableData<mdio::dtypes::uint16_t>>, mdio::Future<mdio::VariableData<mdio::dtypes::uint16_t>>>> GetInlineCrossline(mdio::Dataset& ds) {
+    MDIO_ASSIGN_OR_RETURN(auto il, ds.variables.get<mdio::dtypes::uint16_t>("inline"));
+    MDIO_ASSIGN_OR_RETURN(auto xl, ds.variables.get<mdio::dtypes::uint16_t>("crossline"));
+
+    auto il_fut = il.Read();
+    auto xl_fut = xl.Read();
+
+    return std::make_pair(il_fut, xl_fut);
+}

--- a/examples/seismic_reader/main.hh
+++ b/examples/seismic_reader/main.hh
@@ -1,0 +1,79 @@
+// Copyright 2025 TGS
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "mdio/mdio.h"
+#include "utm.hh"
+#include "stats.hh"
+#include <cmath>
+#include <tuple>
+
+/**
+ * @brief Opens an existing MDIO dataset.
+ * @param path The path to the dataset. May be POSIX, S3, or GCS.
+ * @param cache_size_bytes The size of the LRU cache to be used by the dataset. Defaults to 1GiB.
+ * @return An async future that resolves to the dataset or an error.
+ */
+mdio::Future<mdio::Dataset> OpenDataset(const std::string& path, uint64_t cache_size_bytes = 1024ULL * 1024ULL * 1024ULL);
+
+/**
+ * @brief Retrieves the UTM coordinate futures from the dataset.
+ * @param ds The seismic dataset.
+ * @return A pair of futures, the CDP-X and CDP-Y coordinates.
+ */
+mdio::Result<std::pair<mdio::Future<mdio::VariableData<mdio::dtypes::float64_t>>, mdio::Future<mdio::VariableData<mdio::dtypes::float64_t>>>> GetUTMCoords(mdio::Dataset& ds);
+
+/**
+ * @brief Retrieves the inline and crossline futures from the dataset.
+ * @param ds The seismic dataset.
+ * @return A pair of futures, the inline and crossline coordinates.
+ */
+mdio::Result<std::pair<mdio::Future<mdio::VariableData<mdio::dtypes::uint16_t>>, mdio::Future<mdio::VariableData<mdio::dtypes::uint16_t>>>> GetInlineCrossline(mdio::Dataset& ds);
+
+/**
+ * @brief An example of how to get extents of a VariableData object.
+ * This is a simple function that assumes the passed VariableData object holds some coordinate
+ * data which may not be sorted. Appropriate uses may be checking dimension coordinates such as inline, crossline, time, etc.
+ * or checking UTM coordinates.
+ * 
+ * This function does not take any possible liveness into account.
+ * 
+ * @tparam T The type of the coordinate data.
+ * @param var The VariableData object to get the extents of.
+ * @return A tuple containing the minimum and maximum values of the coordinate data.
+ */
+template <typename T>
+std::tuple<T, T> GetExtents(mdio::VariableData<T>& var) {
+    auto dataPtr = var.get_data_accessor().data();
+    auto offset = var.get_flattened_offset();
+    auto num_samples = var.num_samples();
+    
+    auto result = std::minmax_element(dataPtr + offset, dataPtr + offset + num_samples);
+    return std::make_tuple(*(result.first), *(result.second));
+}
+
+// Fold expression operator<< for tuples.
+// Allows for easy printing of tuples.
+template<class... Args>
+std::ostream& operator<<(std::ostream& os, const std::tuple<Args...>& t) {
+    os << "(";
+    std::apply([&os](const auto&... args) {
+        std::size_t n{0};
+        ((os << (n++ ? ", " : "") << args), ...);
+    }, t);
+    os << ")";
+    return os;
+}
+

--- a/examples/seismic_reader/stats.hh
+++ b/examples/seismic_reader/stats.hh
@@ -1,0 +1,223 @@
+// Copyright 2025 TGS
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "mdio/mdio.h"
+
+namespace stats {
+
+// Forward declaration
+template <typename CoordinateType>
+mdio::Result<std::tuple<CoordinateType, CoordinateType>> GetCoordinatePair(mdio::Future<mdio::VariableData<CoordinateType>>& inlineFuture, mdio::Future<mdio::VariableData<CoordinateType>>& crosslineFuture, const mdio::Index inline_idx, const mdio::Index crossline_idx);
+
+/**
+ * @brief A struct containing the statistics of a seismic volume.
+ * @tparam TraceType The type of the trace data.
+ * @tparam CoordinateType The type of the coordinate data.
+ */
+template <typename TraceType, typename CoordinateType>
+struct VolumeStats {
+    /// The average amplitude of the seismic volume.
+    TraceType avg_amplitude;
+    /// The maximum amplitude of the seismic volume.
+    TraceType max_amplitude;
+    /// The minimum amplitude of the seismic volume.
+    TraceType min_amplitude;
+    /// The inline index of the peak amplitude.
+    CoordinateType peak_amplitude_inline;
+    /// The crossline index of the peak amplitude.
+    CoordinateType peak_amplitude_crossline;
+    /// The inline index of the trough amplitude.
+    CoordinateType trough_amplitude_inline;
+    /// The crossline index of the trough amplitude.
+    CoordinateType trough_amplitude_crossline;
+    /// The number of samples in the seismic volume.
+    uint64_t num_samples;
+
+    /**
+     * @brief A friend function to print the statistics of the seismic volume.
+     * @param os The output stream to print the statistics to.
+     * @param stats The statistics to print.
+     * @return The output stream.
+     */
+    friend std::ostream& operator<<(std::ostream& os, const VolumeStats& stats) {
+        os << "Average amplitude: " << stats.avg_amplitude << std::endl;
+        os << "Max amplitude: " << stats.max_amplitude << std::endl;
+        os << "Min amplitude: " << stats.min_amplitude << std::endl;
+        os << "Peak amplitude inline: " << stats.peak_amplitude_inline << std::endl;
+        os << "Peak amplitude crossline: " << stats.peak_amplitude_crossline << std::endl;
+        os << "Trough amplitude inline: " << stats.trough_amplitude_inline << std::endl;
+        os << "Trough amplitude crossline: " << stats.trough_amplitude_crossline << std::endl;
+        os << "Number of samples: " << stats.num_samples << std::endl;
+        return os;
+    }
+};
+
+/**
+ * @brief Calculate the statistics of a (subset) seismic volume tracewise.
+ * 
+ * This function demonstrates an efficient way to access our 3D seismic data in a trace-wise manner.
+ * 
+ * @tparam TraceType The type of the trace data.
+ * @tparam CoordinateType The type of the coordinate data.
+ * @param ds The dataset to calculate the statistics of.
+ * @return A VolumeStats object containing the statistics.
+ */
+template <typename TraceType, typename CoordinateType>
+mdio::Result<VolumeStats<TraceType, CoordinateType>> CalculateVolumeStatistics(mdio::Dataset& ds) {
+
+    // We could get the chunk sizes from the Variable objects, but for simplicity, we will just use these constants.
+    // See the Variable::get_chunk_shape() method for more information.
+    const mdio::Index INLINE_CHUNK_SIZE = 128;
+    const mdio::Index CROSSLINE_CHUNK_SIZE = 128;
+    // These are arbitrary indices that align with the beginning of a chunk.
+    const mdio::Index INLINE_START = 512;
+    const mdio::Index CROSSLINE_START = 256;
+
+    // Initialize the statistics object.
+    VolumeStats<TraceType, CoordinateType> stats = {
+        .avg_amplitude = 0,
+        .max_amplitude = std::numeric_limits<TraceType>::min(),
+        .min_amplitude = std::numeric_limits<TraceType>::max(),
+        .peak_amplitude_inline = 0,
+        .peak_amplitude_crossline = 0,
+        .trough_amplitude_inline = 0,
+        .trough_amplitude_crossline = 0,
+        .num_samples = 0
+    };
+
+    // First, we are going to enter some arbitrary inline and crossline indices that align with the beginning of a chunk.
+    mdio::RangeDescriptor<> inlineDesc = {"inline", INLINE_START, INLINE_START + INLINE_CHUNK_SIZE, 1};
+    mdio::RangeDescriptor<> crosslineDesc = {"crossline", CROSSLINE_START, CROSSLINE_START + CROSSLINE_CHUNK_SIZE, 1};
+    // We will not slice the time dimension, as we want the full trace length.
+
+    // We will set up these range descriptors to hold our local indices as we iterate inside our subset dataset.
+    mdio::RangeDescriptor<> inlineIndexDesc = {"inline", 0, INLINE_CHUNK_SIZE, 1};
+    mdio::RangeDescriptor<> crosslineIndexDesc = {"crossline", 0, CROSSLINE_CHUNK_SIZE, 1};
+    
+    // Iterate over the inline and crossline chunks.
+    for (mdio::Index inline_idx = INLINE_START; inline_idx<INLINE_START + INLINE_CHUNK_SIZE; inline_idx += INLINE_CHUNK_SIZE) {
+        for (mdio::Index crossline_idx = CROSSLINE_START; crossline_idx<CROSSLINE_START + CROSSLINE_CHUNK_SIZE; crossline_idx += CROSSLINE_CHUNK_SIZE) {
+
+            // Set up the slicing descriptors with the current global chunk to process.
+            inlineDesc.start = inline_idx;
+            inlineDesc.stop = inline_idx + INLINE_CHUNK_SIZE;
+            crosslineDesc.start = crossline_idx;
+            crosslineDesc.stop = crossline_idx + CROSSLINE_CHUNK_SIZE;
+
+            // Ensure our local indices are reset to the start of the chunk.
+            inlineIndexDesc.start = 0;
+            crosslineIndexDesc.start = 0;
+
+            // The result of the isel operation is a new Dataset object with the index extents we described above.
+            MDIO_ASSIGN_OR_RETURN(auto sliced_ds, ds.isel(inlineDesc, crosslineDesc));
+
+            // Now we get the relevant Variables from the sliced dataset to do our statistics.
+            MDIO_ASSIGN_OR_RETURN(auto traceVariable, sliced_ds.variables.get<TraceType>("seismic"));
+            MDIO_ASSIGN_OR_RETURN(auto inlineVariable, sliced_ds.variables.get<CoordinateType>("inline"));
+            MDIO_ASSIGN_OR_RETURN(auto crosslineVariable, sliced_ds.variables.get<CoordinateType>("crossline"));
+            MDIO_ASSIGN_OR_RETURN(auto timeVariable, sliced_ds.variables.get<CoordinateType>("time"));
+
+            // Read is an asynchronous operation which executes immediately and with multiple threads and processes.
+            auto traceFuture = traceVariable.Read();
+            auto inlineFuture = inlineVariable.Read();
+            auto crosslineFuture = crosslineVariable.Read();
+            // We don't need to read the time Variable, we just get it from the sliced dataset to get the trace length.
+
+            // Calling the value() and status() methods are blocking operations that wait for the future to complete and resolve.
+            if (!traceFuture.status().ok()) {
+                return traceFuture.status();
+            }
+
+            // We only need to wait for the trace to resolve, as the coordinates won't be needed until after the first trace is processed.
+            auto trace = traceFuture.value();  // Resolve the future into a strongly typed VariableData object.
+            auto tracePtr = trace.get_data_accessor().data();  // Get a pointer to the flattened trace data.
+            auto traceOffset = trace.get_flattened_offset();  // The flattened trace data may have some constant pointer offset at the start.
+            auto traceLength = timeVariable.num_samples();  // Notice, we used the time Variable to get the trace length.
+
+            auto numTraceSamples = trace.num_samples();  // This gives us the total number of samples in the chunk.
+
+            // Now, we are going to process the data tracewise.
+            for (mdio::Index traceIdx = 0; traceIdx < numTraceSamples; traceIdx += traceLength) {
+                auto local_minmax = std::minmax_element(tracePtr + traceOffset + traceIdx, tracePtr + traceOffset + traceIdx + traceLength);
+                auto local_min = *(local_minmax.first);
+                auto local_max = *(local_minmax.second);
+
+                // Calculate the average amplitude for this trace.
+                auto local_avg = std::accumulate(tracePtr + traceOffset + traceIdx, tracePtr + traceOffset + traceIdx + traceLength, 0.0) / traceLength;
+                stats.avg_amplitude += local_avg;
+
+                if (local_max > stats.max_amplitude) {
+                    stats.max_amplitude = local_max;
+                    MDIO_ASSIGN_OR_RETURN(auto coords, GetCoordinatePair(inlineFuture, crosslineFuture, inlineIndexDesc.start, crosslineIndexDesc.start));
+                    stats.peak_amplitude_inline = std::get<0>(coords);
+                    stats.peak_amplitude_crossline = std::get<1>(coords);
+                }
+                if (local_min < stats.min_amplitude) {
+                    stats.min_amplitude = local_min;
+                    MDIO_ASSIGN_OR_RETURN(auto coords, GetCoordinatePair(inlineFuture, crosslineFuture, inlineIndexDesc.start, crosslineIndexDesc.start));
+                    stats.trough_amplitude_inline = std::get<0>(coords);
+                    stats.trough_amplitude_crossline = std::get<1>(coords);
+                }
+
+                // Increment the local indices of the chunk. 
+                inlineIndexDesc.start += inlineIndexDesc.step;
+                if (inlineIndexDesc.start >= inlineIndexDesc.stop) {
+                    inlineIndexDesc.start = 0;
+                    crosslineIndexDesc.start += crosslineIndexDesc.step;
+                    if (crosslineIndexDesc.start >= crosslineIndexDesc.stop) {
+                        crosslineIndexDesc.start = 0;
+                    }
+                }
+            }
+            stats.num_samples += numTraceSamples;
+        }
+    }
+    stats.avg_amplitude /= stats.num_samples;
+    return stats;
+}
+
+/**
+ * @brief Gets the inline and crossline coordinate value pairs for the given inline and crossline indices.
+ * @tparam CoordinateType The type of the coordinate data.
+ * @param inlineFuture The future containing the inline coordinate data.
+ * @param crosslineFuture The future containing the crossline coordinate data.
+ * @param inline_idx The inline index to get the coordinate value for.
+ * @param crossline_idx The crossline index to get the coordinate value for.
+ * @return A tuple containing the inline and crossline coordinate value pairs.
+ */
+template <typename CoordinateType>
+mdio::Result<std::tuple<CoordinateType, CoordinateType>> GetCoordinatePair(mdio::Future<mdio::VariableData<CoordinateType>>& inlineFuture, mdio::Future<mdio::VariableData<CoordinateType>>& crosslineFuture, const mdio::Index inline_idx, const mdio::Index crossline_idx) {
+    // Ensure that the futures are able to be resolved without error.
+    if (!inlineFuture.status().ok()) {
+        return inlineFuture.status();
+    }
+    if (!crosslineFuture.status().ok()) {
+        return crosslineFuture.status();
+    }
+    // Resolve the futures into VariableData objects
+    auto inlineData = inlineFuture.value();
+    auto crosslineData = crosslineFuture.value();
+    // Get the pointers to their data
+    auto inlinePtr = inlineData.get_data_accessor().data();
+    auto crosslinePtr = crosslineData.get_data_accessor().data();
+    // They will likely have some pointer offset before the actual data starts, so we need to add that to the index.
+    auto inlineOffset = inlineData.get_flattened_offset();
+    auto crosslineOffset = crosslineData.get_flattened_offset();
+    // Build the tuple of the inline and crossline coordinate values and return it.
+    return std::make_tuple(inlinePtr[inlineOffset + inline_idx], crosslinePtr[crosslineOffset + crossline_idx]);
+}
+
+} // namespace stats

--- a/examples/seismic_reader/utm.hh
+++ b/examples/seismic_reader/utm.hh
@@ -1,0 +1,318 @@
+// Copyright 2025 TGS
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "mdio/mdio.h"
+#include <tuple>
+#include <cmath>
+#include <sstream>
+#include <iomanip>
+#include <iostream>
+#include <type_traits>
+
+namespace utm {
+
+/**
+ * @brief Base class for coordinate pairs
+ */
+struct CoordPair {
+    double first;
+    double second;
+    
+    CoordPair(double a = 0.0, double b = 0.0) : first(a), second(b) {}
+};
+
+/**
+ * @brief Geographic coordinates (latitude, longitude) in decimal degrees
+ */
+struct GeoCoord : public CoordPair {
+    GeoCoord(double lat = 0.0, double lon = 0.0) : CoordPair(lat, lon) {}
+    
+    double& latitude = first;
+    double& longitude = second;
+};
+
+/**
+ * @brief UTM coordinates (easting, northing) in meters
+ */
+struct UTMCoord : public CoordPair {
+    UTMCoord(double e = 0.0, double n = 0.0) : CoordPair(e, n) {}
+    
+    double& easting = first;
+    double& northing = second;
+};
+
+/**
+ * @brief Represents the extent (min, max) of coordinates
+ */
+struct CoordExtent : public CoordPair {
+    CoordExtent(double mn = 0.0, double mx = 0.0) : CoordPair(mn, mx) {}
+    
+    double& min = first;
+    double& max = second;
+
+    /**
+     * @brief Check if this extent represents a single point (min equals max)
+     * @return true if min equals max, false otherwise
+     */
+    bool is_point() const {
+        return min == max;
+    }
+};
+
+/**
+ * @brief Convert UTM coordinates (easting, northing) to geographic coordinates (latitude, longitude)
+ * for GDA94 / MGA Zone 51
+ * 
+ * @param utm UTM coordinates in meters
+ * @return GeoCoord Geographic coordinates in decimal degrees
+ */
+inline GeoCoord utm_to_geo(const UTMCoord& utm) {
+    // Constants for GDA94 / MGA Zone 51 (EPSG:28351)
+    const double a = 6378137.0;           // Semi-major axis
+    const double f = 1.0 / 298.257222101; // Flattening
+    const double k0 = 0.9996;             // Scale factor
+    const double central_meridian = 123.0; // Central meridian for Zone 51
+    const double false_easting = 500000.0; // False easting
+    const double false_northing = 10000000.0; // False northing (Southern Hemisphere)
+    
+    // Calculate ellipsoid parameters
+    const double e2 = 2 * f - f * f;      // Eccentricity squared
+    const double e_prime_squared = e2 / (1 - e2);
+    
+    // Adjust for false easting and northing
+    const double x = utm.easting - false_easting;
+    const double y = utm.northing - false_northing;
+    
+    // Meridian distance
+    const double m = y / k0;
+    
+    // Footprint latitude
+    const double mu = m / (a * (1 - e2/4 - 3*e2*e2/64 - 5*e2*e2*e2/256));
+    
+    // Coefficients for footprint latitude
+    const double e1 = (1 - sqrt(1 - e2)) / (1 + sqrt(1 - e2));
+    const double j1 = 3*e1/2 - 27*e1*e1*e1/32;
+    const double j2 = 21*e1*e1/16 - 55*e1*e1*e1*e1/32;
+    const double j3 = 151*e1*e1*e1/96;
+    const double j4 = 1097*e1*e1*e1*e1/512;
+    
+    // Footprint latitude
+    const double fp = mu + j1*sin(2*mu) + j2*sin(4*mu) + j3*sin(6*mu) + j4*sin(8*mu);
+    
+    // Calculate parameters
+    const double cos_fp = cos(fp);
+    const double sin_fp = sin(fp);
+    const double tan_fp = tan(fp);
+    
+    const double C1 = e_prime_squared * cos_fp * cos_fp;
+    const double T1 = tan_fp * tan_fp;
+    const double R1 = a * (1 - e2) / pow(1 - e2 * sin_fp * sin_fp, 1.5);
+    const double N1 = a / sqrt(1 - e2 * sin_fp * sin_fp);
+    
+    const double D = x / (N1 * k0);
+    
+    // Calculate latitude
+    const double lat_rad = fp - (tan_fp / (R1 * N1)) * (
+        D*D/2 - 
+        (5 + 3*T1 + 10*C1 - 4*C1*C1 - 9*e_prime_squared) * D*D*D*D/24 + 
+        (61 + 90*T1 + 298*C1 + 45*T1*T1 - 252*e_prime_squared - 3*C1*C1) * D*D*D*D*D*D/720
+    );
+    
+    // Calculate longitude
+    const double lon_rad = central_meridian * M_PI / 180.0 + (
+        D - 
+        (1 + 2*T1 + C1) * D*D*D/6 + 
+        (5 - 2*C1 + 28*T1 - 3*C1*C1 + 8*e_prime_squared + 24*T1*T1) * D*D*D*D*D/120
+    ) / cos_fp;
+    
+    // Convert to degrees
+    GeoCoord result;
+    result.latitude = lat_rad * 180.0 / M_PI;
+    result.longitude = lon_rad * 180.0 / M_PI;
+    
+    return result;
+}
+
+namespace geojson {
+
+/**
+ * @brief Encode a string in URL format.
+ * @param value The string to encode.
+ * @return The encoded string.
+ */
+std::string urlEncode(const std::string &value) {
+    std::ostringstream escaped;
+    escaped.fill('0');
+    escaped << std::hex;
+
+    for (unsigned char c : value) {
+        // Encode reserved characters
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            escaped << c;
+        } else {
+            escaped << '%' << std::uppercase << std::setw(2) << int(c);
+        }
+    }
+    return escaped.str();
+}
+
+/**
+ * @brief Encode a point in GeoJSON format and return a URL to a web map.
+ * @param geo Geographic coordinates (latitude, longitude)
+ * @return A URL to a web map.
+ */
+std::string encodeGeoJSONPointURL(const GeoCoord& geo) {
+    std::ostringstream geojson;
+    geojson << R"({"type":"Point","coordinates":[)"
+            << geo.longitude << "," << geo.latitude << "]}";
+
+    std::string geojsonStr = geojson.str();
+    std::string encodedGeoJSON = urlEncode(geojsonStr);
+
+    return "http://geojson.io/#data=data:application/json," + encodedGeoJSON;
+}
+
+/**
+ * @brief Encode a bounding box in GeoJSON format and return a URL to a web map.
+ * @param x_extents The extents of the coordinates in the x direction.
+ * @param y_extents The extents of the coordinates in the y direction.
+ * @return A URL to a web map.
+ */
+std::string encodeGeoJSONBoundingBoxURL(const CoordExtent& x_extents, const CoordExtent& y_extents) {
+    // Calculate the four corners in UTM coordinates
+    UTMCoord nw = {x_extents.min, y_extents.max};
+    UTMCoord ne = {x_extents.max, y_extents.max};
+    UTMCoord sw = {x_extents.min, y_extents.min};
+    UTMCoord se = {x_extents.max, y_extents.min};
+    
+    // Convert to geographic coordinates
+    GeoCoord nw_geo = utm_to_geo(nw);
+    GeoCoord ne_geo = utm_to_geo(ne);
+    GeoCoord sw_geo = utm_to_geo(sw);
+    GeoCoord se_geo = utm_to_geo(se);
+
+    std::ostringstream geojson;
+    geojson << R"({"type":"Polygon","coordinates":[[)"
+            << "[" << nw_geo.longitude << "," << nw_geo.latitude << "],"
+            << "[" << ne_geo.longitude << "," << ne_geo.latitude << "],"
+            << "[" << se_geo.longitude << "," << se_geo.latitude << "],"
+            << "[" << sw_geo.longitude << "," << sw_geo.latitude << "],"
+            << "[" << nw_geo.longitude << "," << nw_geo.latitude << "]]]}";  // Close the polygon
+
+    std::string geojsonStr = geojson.str();
+    std::string encodedGeoJSON = urlEncode(geojsonStr);
+
+    return "http://geojson.io/#data=data:application/json," + encodedGeoJSON;
+}
+
+}  // namespace geojson
+
+/**
+ * @brief Print the four corners of the geometry in UTM coordinates and their corresponding geographic coordinates.
+ * @param x_extents The extents of the coordinates in the x direction.
+ * @param y_extents The extents of the coordinates in the y direction.
+ */
+void print_corners(const CoordExtent& x_extents, const CoordExtent& y_extents) {
+    // Display the four corners of the geometry
+    std::cout << "\nGeometry Corners (UTM -> Lat/Long):" << std::endl;
+    std::cout << "-------------------------------------" << std::endl;
+    
+    // Check if we're dealing with a point (both extents are points with the same value)
+    if (x_extents.is_point() && y_extents.is_point()) {
+        GeoCoord geo = utm_to_geo({x_extents.min, y_extents.min});
+        std::cout << "Point: E=" << x_extents.min << ", N=" << y_extents.min
+                  << " -> Lat=" << geo.latitude << "°, Lon=" << geo.longitude << "°" << std::endl;
+        return;
+    }
+
+    // Northwest corner
+    UTMCoord nw = {x_extents.min, y_extents.max};
+    GeoCoord nw_geo = utm_to_geo(nw);
+    std::cout << "Northwest: E=" << nw.easting << ", N=" << nw.northing
+              << " -> Lat=" << nw_geo.latitude << "°, Lon=" << nw_geo.longitude << "°" << std::endl;
+
+    // Northeast corner
+    UTMCoord ne = {x_extents.max, y_extents.max};
+    GeoCoord ne_geo = utm_to_geo(ne);
+    std::cout << "Northeast: E=" << ne.easting << ", N=" << ne.northing
+              << " -> Lat=" << ne_geo.latitude << "°, Lon=" << ne_geo.longitude << "°" << std::endl;
+
+    // Southwest corner
+    UTMCoord sw = {x_extents.min, y_extents.min};
+    GeoCoord sw_geo = utm_to_geo(sw);
+    std::cout << "Southwest: E=" << sw.easting << ", N=" << sw.northing
+              << " -> Lat=" << sw_geo.latitude << "°, Lon=" << sw_geo.longitude << "°" << std::endl;
+
+    // Southeast corner
+    UTMCoord se = {x_extents.max, y_extents.min};
+    GeoCoord se_geo = utm_to_geo(se);
+    std::cout << "Southeast: E=" << se.easting << ", N=" << se.northing
+              << " -> Lat=" << se_geo.latitude << "°, Lon=" << se_geo.longitude << "°" << std::endl;
+}
+
+/**
+ * @brief Present a link to a web map with either the maximum area of the available extents or a single point of interest.
+ * @param x_extents The extents of the coordinates in the x direction.
+ * @param y_extents The extents of the coordinates in the y direction.
+ */
+void web_display(const CoordExtent& x_extents, const CoordExtent& y_extents) {
+    // Calculate the four corners in UTM coordinates
+    UTMCoord nw = {x_extents.min, y_extents.max};
+    UTMCoord ne = {x_extents.max, y_extents.max};
+    UTMCoord sw = {x_extents.min, y_extents.min};
+    UTMCoord se = {x_extents.max, y_extents.min};
+    
+    // Convert to geographic coordinates
+    GeoCoord nw_geo = utm_to_geo(nw);
+    GeoCoord ne_geo = utm_to_geo(ne);
+    GeoCoord sw_geo = utm_to_geo(sw);
+    GeoCoord se_geo = utm_to_geo(se);
+    
+    // Check if we're dealing with a point
+    if (x_extents.is_point() && y_extents.is_point()) {
+        std::cout << "Click here to view the point on a global map: " 
+                  << geojson::encodeGeoJSONPointURL(nw_geo) << std::endl;
+    } else {
+        std::cout << "Click here to view the area on a global map: " 
+                  << geojson::encodeGeoJSONBoundingBoxURL(x_extents, y_extents) << std::endl;
+    }
+}
+
+/**
+ * @brief Backward compatibility version of print_corners that accepts tuples
+ * @param cdp_x_extents The extents of the CDP coordinates in the x direction as a tuple.
+ * @param cdp_y_extents The extents of the CDP coordinates in the y direction as a tuple.
+ */
+void print_corners(std::tuple<mdio::dtypes::float64_t, mdio::dtypes::float64_t> cdp_x_extents,
+                  std::tuple<mdio::dtypes::float64_t, mdio::dtypes::float64_t> cdp_y_extents) {
+    CoordExtent x_ext = {std::get<0>(cdp_x_extents), std::get<1>(cdp_x_extents)};
+    CoordExtent y_ext = {std::get<0>(cdp_y_extents), std::get<1>(cdp_y_extents)};
+    print_corners(x_ext, y_ext);
+}
+
+/**
+ * @brief Backward compatibility version of web_display that accepts tuples
+ * @param cdp_x_extents The extents of the CDP coordinates in the x direction as a tuple.
+ * @param cdp_y_extents The extents of the CDP coordinates in the y direction as a tuple.
+ */
+void web_display(std::tuple<mdio::dtypes::float64_t, mdio::dtypes::float64_t> cdp_x_extents,
+                std::tuple<mdio::dtypes::float64_t, mdio::dtypes::float64_t> cdp_y_extents) {
+    CoordExtent x_ext = {std::get<0>(cdp_x_extents), std::get<1>(cdp_x_extents)};
+    CoordExtent y_ext = {std::get<0>(cdp_y_extents), std::get<1>(cdp_y_extents)};
+    web_display(x_ext, y_ext);
+}
+
+} // namespace utm


### PR DESCRIPTION
Add an example of a standalone application linking MDIO statically, reading data, and calculating UTM coordinates.

- Adds an example of building and statically linking MDIO and the dependencies.
- Adds an example of accessing CDP coordinates and performing transform to lat/long.
- Demonstrates efficient access in memory.