### PR TITLE
Fix missing units field and add convenience getter

### DIFF
--- a/mdio/dataset_test.cc
+++ b/mdio/dataset_test.cc
@@ -966,6 +966,46 @@ TEST(Dataset, create) {
       << "Dataset successfully overwrote an existing dataset!";
 }
 
+TEST(Dataset, getVariableUnits) {
+  const std::string path = "zarrs/acceptance";
+  std::filesystem::remove_all("zarrs/acceptance");
+  auto json_vars = GetToyExample();
+
+  auto datasetRes =
+      mdio::Dataset::from_json(json_vars, path, mdio::constants::kCreateClean);
+  ASSERT_TRUE(datasetRes.status().ok()) << datasetRes.status();
+  auto dataset = datasetRes.value();
+
+  auto imageRes = dataset.variables.at("velocity");
+  ASSERT_TRUE(imageRes.ok()) << imageRes.status();
+  auto image = imageRes.value();
+
+  auto unitsRes = image.get_units();
+  ASSERT_TRUE(unitsRes.status().ok()) << unitsRes.status();
+  auto units = unitsRes.value();
+  EXPECT_EQ(units.get<std::string>(), mdio::units::kMetersPerSecond);
+}
+
+TEST(Dataset, getVariableUnitsError) {
+  const std::string path = "zarrs/acceptance";
+  std::filesystem::remove_all("zarrs/acceptance");
+  auto json_vars = GetToyExample();
+
+  auto datasetRes =
+      mdio::Dataset::from_json(json_vars, path, mdio::constants::kCreateClean);
+  ASSERT_TRUE(datasetRes.status().ok()) << datasetRes.status();
+  auto dataset = datasetRes.value();
+
+  auto imageRes = dataset.variables.at("image");
+  ASSERT_TRUE(imageRes.ok()) << imageRes.status();
+  auto image = imageRes.value();
+
+  auto unitsRes = image.get_units();
+  ASSERT_FALSE(unitsRes.status().ok()) << unitsRes.status();
+  EXPECT_EQ(unitsRes.status().message(),
+            "This Variable does not contain units");
+}
+
 TEST(Dataset, commitMetadata) {
   const std::string path = "zarrs/acceptance";
   std::filesystem::remove_all("zarrs/acceptance");

--- a/mdio/impl.h
+++ b/mdio/impl.h
@@ -74,6 +74,48 @@ using byte_t = tensorstore::dtypes::byte_t;
 using bool_t = tensorstore::dtypes::bool_t;
 }  // namespace dtypes
 
+namespace units {
+// Angle units
+constexpr std::string_view kDegrees = "deg";
+constexpr std::string_view kRadians = "rad";
+
+// Density units
+constexpr std::string_view kGramsPerCubicCentimeter = "g/cm**3";
+constexpr std::string_view kKilogramsPerCubicMeter = "kg/m**3";
+constexpr std::string_view kPoundsPerGallon = "lb/gal";
+
+// Frequency units
+constexpr std::string_view kHertz = "Hz";
+
+// Length units
+constexpr std::string_view kMillimeters = "mm";
+constexpr std::string_view kCentimeters = "cm";
+constexpr std::string_view kMeters = "m";
+constexpr std::string_view kKilometers = "km";
+constexpr std::string_view kInches = "in";
+constexpr std::string_view kFeet = "ft";
+constexpr std::string_view kYards = "yd";
+constexpr std::string_view kMiles = "mi";
+
+// Speed units
+constexpr std::string_view kMetersPerSecond = "m/s";
+constexpr std::string_view kFeetPerSecond = "ft/s";
+
+// Time units
+constexpr std::string_view kNanoseconds = "ns";
+constexpr std::string_view kMicroseconds = "µs";
+constexpr std::string_view kMilliseconds = "ms";
+constexpr std::string_view kSeconds = "s";
+constexpr std::string_view kMinutes = "min";
+constexpr std::string_view kHours = "h";
+constexpr std::string_view kDays = "d";
+
+// Voltage units
+constexpr std::string_view kMicrovolts = "µV";
+constexpr std::string_view kMillivolts = "mV";
+constexpr std::string_view kVolts = "V";
+}  // namespace units
+
 // Special constants bleeds
 constexpr DimensionIndex dynamic_rank = tensorstore::dynamic_rank;
 constexpr ArrayOriginKind zero_origin = tensorstore::zero_origin;

--- a/mdio/stats_test.cc
+++ b/mdio/stats_test.cc
@@ -454,4 +454,43 @@ TEST(UserAttributes, locationAndReassignment) {
   // auto newAttrs = std::move(attr)
 }
 
+TEST(Units, unitsFromJsonObject) {
+  // Test when unitsV1 is provided as an object.
+  nlohmann::json json_input = {{"unitsV1", {{"length", "m"}}}};
+  auto uaRes = mdio::UserAttributes::FromJson(json_input);
+  ASSERT_TRUE(uaRes.status().ok()) << uaRes.status();
+  mdio::UserAttributes ua = uaRes.value();
+  // When an object is provided, the FromJson implementation pushes back the
+  // unit value, so with one element it will return directly (not wrapped in an
+  // array)
+  nlohmann::json ua_json = ua.ToJson();
+  EXPECT_TRUE(ua_json.contains("unitsV1"));
+  EXPECT_EQ(ua_json["unitsV1"], "m");
+}
+
+TEST(Units, unitsFromJsonArrayOfObjects) {
+  // Test when unitsV1 is provided as an array of objects.
+  nlohmann::json json_input = {
+      {"unitsV1", {{{"length", "m"}}, {{"time", "s"}}}}};
+  auto uaRes = mdio::UserAttributes::FromJson(json_input);
+  ASSERT_TRUE(uaRes.status().ok()) << uaRes.status();
+  mdio::UserAttributes ua = uaRes.value();
+  nlohmann::json ua_json = ua.ToJson();
+  EXPECT_TRUE(ua_json.contains("unitsV1"));
+  // With more than one unit, the units-bindable returns an array.
+  nlohmann::json expected = {"m", "s"};
+  EXPECT_EQ(ua_json["unitsV1"], expected);
+}
+
+TEST(Units, unitsFromJsonString) {
+  // Test when unitsV1 is provided as a plain string.
+  nlohmann::json json_input = {{"unitsV1", "rad"}};
+  auto uaRes = mdio::UserAttributes::FromJson(json_input);
+  ASSERT_TRUE(uaRes.status().ok()) << uaRes.status();
+  mdio::UserAttributes ua = uaRes.value();
+  nlohmann::json ua_json = ua.ToJson();
+  EXPECT_TRUE(ua_json.contains("unitsV1"));
+  EXPECT_EQ(ua_json["unitsV1"], "rad");
+}
+
 }  // namespace

--- a/mdio/variable.h
+++ b/mdio/variable.h
@@ -1387,6 +1387,18 @@ class Variable {
     return (*attributes)->ToJson();
   }
 
+  Result<nlohmann::json> get_units() const {
+    auto attrs = GetAttributes();
+
+    // Return units if they exist and are non-null.
+    if (attrs.contains("unitsV1") && !attrs["unitsV1"].is_null()) {
+      return attrs["unitsV1"];
+    }
+
+    // Return an error if the units do not exist.
+    return absl::InvalidArgumentError("This Variable does not contain units");
+  }
+
   /**
    * @brief Gets the entire metadata of the Variable.
    * Returned object is expected to have a parent key of "metadata".

--- a/mdio/variable_test.cc
+++ b/mdio/variable_test.cc
@@ -51,11 +51,12 @@
                     {"job status", "win"},  // can be anything
                     {"project code", "fail"}
                 }
-            }}
+            },
+            {"unitsV1", {"m", "ft"}}  // moved to be directly in metadata
+            }
         },
         {"long_name", "foooooo ....."},  // required
         {"dimension_names", {"x", "y"} },  // required
-        {"dimension_units", {"m", "ft"} },  // optional (if coord).
     }},
     {"metadata",
         {
@@ -78,7 +79,7 @@
         }
     },
     {"attributes",
-        {{"dimension_units", {"m", "ft"} },  // optional (if coord).
+        {{"unitsV1", {"m", "ft"} },  // optional (if coord).
             {"metadata",
                 {{"attributes",  // optional misc attributes.
                     {
@@ -731,6 +732,16 @@ TEST(Variable, userAttributes) {
       << "An update to the UserAttributes was not detected";
   EXPECT_TRUE(var2Sliced.was_updated())
       << "An update to the UserAttributes was not detected";
+}
+
+TEST(Variable, getUnitsPresent) {
+  auto var1Res =
+      mdio::Variable<>::Open(json_good, mdio::constants::kCreateClean);
+  ASSERT_TRUE(var1Res.status().ok()) << var1Res.status();
+  auto var1 = var1Res.value();
+
+  auto unitsRes = var1.get_units();
+  ASSERT_TRUE(unitsRes.status().ok()) << unitsRes.status();
 }
 
 // If a slice is "out of bounds" it should automatically get resized to the


### PR DESCRIPTION
Initial implementation of `stats.h` did not include unitsV1 field, causing this data to be lost in memory. This bug did not impact on-disk data.