### PR TITLE
fix: clear PUBLIC_HEADER before re-installing json schema validator

### DIFF
--- a/cmake/Findnlohmann_json_schema_validator.cmake
+++ b/cmake/Findnlohmann_json_schema_validator.cmake
@@ -28,6 +28,12 @@ if (NOT TARGET nlohmann_json_schema_validator)
   target_link_libraries(nlohmann_json_schema_validator INTERFACE nlohmann_json::nlohmann_json)
 
   # Install the validator target
+  # The validator sets PUBLIC_HEADER to a path relative to its own source tree.
+  # We re-install the target only to add it to the mdioTargets export set; we must
+  # NOT re-copy its public header (the validator installs it itself, to
+  # include/nlohmann/). Clearing the property stops install(TARGETS) from resolving
+  # the relative header path against this directory and failing.
+  set_target_properties(nlohmann_json_schema_validator PROPERTIES PUBLIC_HEADER "")
   install(TARGETS nlohmann_json_schema_validator
     EXPORT mdioTargets
   )


### PR DESCRIPTION
The bundled nlohmann_json_schema_validator declares its PUBLIC_HEADER with a path relative to its own source tree. Re-installing the target from the mdio scope resolved that path against the wrong directory, so make install aborted on a missing nlohmann/json-schema.hpp. Clear the property before install(TARGETS) so the redundant header copy is skipped; the validator still installs its own header and the export set is preserved.